### PR TITLE
bake classified notes with custom title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Create `BakeCustomTitledNotes` for notes with classes that have custom title (minor)
 * Add more updates to `pl-economics` recipe bake file. Fix `shorten` script paths, change kitchen.ci to cookbook in docker run `rubocop` file (patch)
 
 ## [19.0.0] - 2022-1-28

--- a/lib/kitchen/directions/bake_notes/bake_custom_titled_notes.rb
+++ b/lib/kitchen/directions/bake_notes/bake_custom_titled_notes.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Kitchen
+  module Directions
+    module BakeCustomTitledNotes
+      def self.v1(book:, classes:)
+        book.notes.each do |note|
+          next unless (note.classes & classes).any?
+
+          bake_note(note: note)
+        end
+      end
+
+      def self.bake_note(note:)
+        note.wrap_children(class: 'os-note-body')
+
+        title = note.title&.cut
+        return unless title
+
+        note.prepend(child:
+          <<~HTML
+            <h3 class="os-title" data-type="title">
+              <span class="os-title-label" id="#{title[:id]}">#{title.children}</span>
+            </h3>
+          HTML
+        )
+      end
+    end
+  end
+end

--- a/spec/kitchen_spec/directions/bake_notes/bake_custom_titled_notes_spec.rb
+++ b/spec/kitchen_spec/directions/bake_notes/bake_custom_titled_notes_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Kitchen::Directions::BakeCustomTitledNotes do
+
+  let(:book_with_notes) do
+    book_containing(html:
+      one_chapter_with_one_page_containing(
+        <<~HTML
+          <div data-type="note" id="untitlednote" class="foo">
+            <p>content</p>
+          </div>
+          <div data-type="note" id="titlednote" class="bar">
+            <div data-type="title" id="titleId">note title</div>
+            <p>content</p>
+          </div>
+        HTML
+      )
+    )
+  end
+
+  it 'bakes' do
+    described_class.v1(book: book_with_notes, classes: %w[foo bar])
+    expect(book_with_notes.body.pages.first).to match_normalized_html(
+      <<~HTML
+        <div data-type="page">
+          <div data-type="note" id="untitlednote" class="foo">
+            <div class="os-note-body">
+              <p>content</p>
+            </div>
+          </div>
+          <div data-type="note" id="titlednote" class="bar">
+            <h3 class="os-title" data-type="title">
+              <span class="os-title-label" id="titleId">note title</span>
+            </h3>
+            <div class="os-note-body">
+              <p>content</p>
+            </div>
+          </div>
+        </div>
+      HTML
+    )
+  end
+end


### PR DESCRIPTION
Done for Marketing. 

There are some notes that have classes, but they're not using titles created by recipe. They could have existing title or none.