### PR TITLE
Fix dependency doubling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 * Update locales files, specs for pl microeconomics, pl-u-physics, pl-psychology (patch)
 * Add support for tables wioth classes `data-table`, `timeline-table` to `BakeNumberedTable.v1`
 * Change iframes behavior to include the (url...) in link (major)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,10 +40,10 @@ WORKDIR /code
 COPY . /code/
 
 RUN gem install bundler --no-document --version $bundler_version && \
+    bundle install && \
     gem install solargraph && \
     gem install lefthook && \
     bundle config set no-cache 'true' && \
     bundle config set silence_root_warning 'true' && \
-    bundle install && \
     echo "Generating YARD documentation for gems (this can be slow)..." && \
     bundle exec yard gems --quiet


### PR DESCRIPTION
Nokogiri was being installed twice, once with the pinned version in the gemfile and once with the current version (which creates some problems). Turns out that the call to `gem install solargraph` in the Dockerfile was installing nokogiri, defaulting to the current version without other specification. Calling `bundle install` first installs the correct version without the doubling.