### PR TITLE
Precalculo Exercise Transalation Patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Switch kitchen tests over to snapshots
+* Patch Precalculus recipe for precalculo
 
 ## [v1.5.0] - 2022-04-18
 

--- a/lib/recipes/precalculus/locales/es.yml
+++ b/lib/recipes/precalculus/locales/es.yml
@@ -1,5 +1,5 @@
 es:
-  section_exercises: ! '%{number} Ejercicios de Sección'
+  section_exercises: ! '%{number} Ejercicios de sección'
   eoc:
     practice-test: Examen de práctica
     review-exercises: Ejercicios de repaso

--- a/lib/recipes/precalculus/precalculus_recipe.rb
+++ b/lib/recipes/precalculus/precalculus_recipe.rb
@@ -52,7 +52,7 @@ PRECALCULUS_RECIPE = Kitchen::BookRecipe.new(book_short_name: :precalculus) do |
       ) do |exercise_section|
         Kitchen::Directions::RemoveSectionTitle.v1(section: exercise_section)
         exercise_section.search('section').each do |section|
-          section.first('h4').name = 'h5'
+          section.first('h4')&.name = 'h5'
         end
       end
     end


### PR DESCRIPTION
[#4617](https://app.zenhub.com/workspaces/ce-styles-5cdc84baee941c07853fbbf2/issues/openstax/cnx-recipes/4617)

Also adds a bit to the precal recipe to ignore exercise sections without h4 titles (so it doesn't crash precalculo)