### PR TITLE
add options parameter to pass options to BakeNumberedExercise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `options` parameter to pass options to `BakeNumberedExercise`
 * Add optional baking exercise problem title to `BakeExample` direction for `statistics`
 * Add support for baking learning objectives in appendices (`BakeLearningObjectives`) for `marketing`
 

--- a/lib/kitchen/directions/bake_all_numbered_exercise_types.rb
+++ b/lib/kitchen/directions/bake_all_numbered_exercise_types.rb
@@ -10,9 +10,9 @@ module Kitchen
           next if exercise.has_class?('unnumbered')
 
           if exercise.instance_of?(ExerciseElement)
-            exercise_options[:exercise] = exercise
-            exercise_options[:number] = exercise_counter
-            BakeNumberedExercise.v1(exercise_options)
+            BakeNumberedExercise.v1(
+              exercise: exercise, number: exercise_counter, options: exercise_options
+            )
           else
             question_options[:number] = exercise_counter
             question_options[:question] = exercise

--- a/lib/kitchen/directions/bake_numbered_exercise/main.rb
+++ b/lib/kitchen/directions/bake_numbered_exercise/main.rb
@@ -3,7 +3,12 @@
 module Kitchen
   module Directions
     module BakeNumberedExercise
-      def self.v1(exercise:, number:, options: {})
+      def self.v1(exercise:, number:, options: {
+        suppress_solution_if: false,
+        note_suppressed_solutions: false,
+        cases: false,
+        solution_stays_put: false
+      })
         # any option that is passed in will override the defaults,
         # but if some options not given, default will be used.
         options.reverse_merge!(

--- a/lib/kitchen/directions/bake_numbered_exercise/main.rb
+++ b/lib/kitchen/directions/bake_numbered_exercise/main.rb
@@ -3,15 +3,17 @@
 module Kitchen
   module Directions
     module BakeNumberedExercise
-      # rubocop:disable Metrics/ParameterLists
-      # :/
-      def self.v1(exercise:, number:, suppress_solution_if: false,
-                  note_suppressed_solutions: false, cases: false, solution_stays_put: false)
-        V1.new.bake(exercise: exercise, number: number, suppress_solution_if: suppress_solution_if,
-                    note_suppressed_solutions: note_suppressed_solutions, cases: cases,
-                    solution_stays_put: solution_stays_put)
+      def self.v1(exercise:, number:, options: {})
+        # any option that is passed in will override the defaults,
+        # but if some options not given, default will be used.
+        options.reverse_merge!(
+          suppress_solution_if: false,
+          note_suppressed_solutions: false,
+          cases: false,
+          solution_stays_put: false
+        )
+        V1.new.bake(exercise: exercise, number: number, options: options)
       end
-      # rubocop:enable Metrics/ParameterLists
 
       def self.bake_solution_v1(exercise:, number:, divider: '. ')
         V1.new.bake_solution(exercise: exercise, number: number, divider: divider,

--- a/lib/recipes/biology/bake
+++ b/lib/recipes/biology/bake
@@ -35,7 +35,7 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :biology) do |doc|
       'section.visual-exercise, section.multiple-choice, section.critical-thinking'
     chapter.search(exercise_selectors).exercises.each do |exercise|
       BakeNumberedExercise.v1(exercise: exercise, number: exercise.count_in(:chapter),
-                              suppress_solution_if: true)
+                              options: { suppress_solution_if: true })
     end
 
     chapter.figures(only: :figure_to_number?).each do |figure|

--- a/lib/recipes/college-physics/bake
+++ b/lib/recipes/college-physics/bake
@@ -13,7 +13,7 @@ college_physics = Kitchen::BookRecipe.new(book_short_name: :college_physics) do 
   book.chapters.each do |chapter|
     chapter.sections('$.problems-exercises').exercises.each do |exercise|
       BakeNumberedExercise.v1(
-        exercise: exercise, number: exercise.count_in(:chapter), suppress_solution_if: true)
+        exercise: exercise, number: exercise.count_in(:chapter), options: { suppress_solution_if: true })
     end
     BakeLearningObjectives.v3(chapter: chapter)
   end

--- a/lib/recipes/college-physics/college_physics_recipe.rb
+++ b/lib/recipes/college-physics/college_physics_recipe.rb
@@ -46,7 +46,9 @@ COLLEGE_PHYSICS_RECIPE = Kitchen::BookRecipe.new(book_short_name: :college_physi
 
     chapter.sections('$.conceptual-questions').exercises.each do |exercise|
       BakeNumberedExercise.v1(
-        exercise: exercise, number: exercise.count_in(:chapter), suppress_solution_if: true)
+        exercise: exercise, number: exercise.count_in(:chapter),
+        options: { suppress_solution_if: true }
+      )
       BakeFirstElements.v1(within: exercise)
     end
 

--- a/lib/recipes/history/bake
+++ b/lib/recipes/history/bake
@@ -37,8 +37,10 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :history) do |doc|
         BakeNumberedExercise.v1(
           exercise: exercise,
           number: exercise.count_in(:chapter),
-          suppress_solution_if: :even?,
-          note_suppressed_solutions: true
+          options: {
+            suppress_solution_if: :even?,
+            note_suppressed_solutions: true
+          }
         )
       else
         BakeNumberedExercise.v1(exercise: exercise, number: exercise.count_in(:chapter))

--- a/lib/recipes/pl-economics/bake
+++ b/lib/recipes/pl-economics/bake
@@ -54,7 +54,10 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :pleconomics) do |doc|
                                   critical-thinking problems]
 
     chapter.search(exercise_section_classes.prefix('section.')).exercises.each do |exercise|
-      BakeNumberedExercise.v1(exercise: exercise, number: exercise.count_in(:chapter), cases: true)
+      BakeNumberedExercise.v1(
+        exercise: exercise, number: exercise.count_in(:chapter),
+        options: { cases: true }
+      )
     end
 
     exercise_section_classes.each do |klass|
@@ -116,9 +119,10 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :pleconomics) do |doc|
     end
 
     page.search('section').exercises.each do |exercise|
-      BakeNumberedExercise.v1(exercise: exercise,
-                              number: "#{appendix_letter}#{exercise.count_in(:page)}",
-                              cases: true)
+      BakeNumberedExercise.v1(
+        exercise: exercise, number: "#{appendix_letter}#{exercise.count_in(:page)}",
+        options: { cases: true }
+      )
       BakeFirstElements.v1(within: exercise)
     end
   end

--- a/lib/recipes/pl-psychology/bake
+++ b/lib/recipes/pl-psychology/bake
@@ -83,10 +83,10 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :plpsychology) do |doc|
 
     selectors = 'section.review-questions, section.critical-thinking, section.personal-application'
     chapter.search(selectors).exercises.each do |exercise|
-      BakeNumberedExercise.v1(exercise: exercise,
-                              number: exercise.count_in(:chapter),
-                              suppress_solution_if: true,
-                              cases: true)
+      BakeNumberedExercise.v1(
+        exercise: exercise, number: exercise.count_in(:chapter),
+        options: { suppress_solution_if: true, cases: true }
+      )
     end
   end
 

--- a/lib/recipes/pl-u-physics/bake
+++ b/lib/recipes/pl-u-physics/bake
@@ -91,7 +91,10 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :pluphysics) do |doc|
     exercise_selectors = 'section.review-conceptual-questions, section.review-problems, ' \
                          'section.review-additional-problems, section.review-challenge'
     chapter.search(exercise_selectors).exercises.each do |exercise|
-      BakeNumberedExercise.v1(exercise: exercise, number: exercise.count_in(:chapter), cases: true)
+      BakeNumberedExercise.v1(
+        exercise: exercise, number: exercise.count_in(:chapter),
+        options: { cases: true }
+      )
     end
 
     answer_key_inner_container = AnswerKeyInnerContainer.v1(

--- a/lib/recipes/sociology/bake
+++ b/lib/recipes/sociology/bake
@@ -44,10 +44,10 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :sociology) do |doc|
     BakeFurtherResearch.v1(chapter: chapter, metadata_source: metadata)
     chapter.composite_pages.each do |composite_page|
       composite_page.search('section.short-answer, section.section-quiz').exercises.each do |exercise|
-        BakeNumberedExercise.v1(exercise: exercise,
-                                number: exercise.count_in(:composite_page),
-                                suppress_solution_if: :even?,
-                                note_suppressed_solutions: true)
+        BakeNumberedExercise.v1(
+          exercise: exercise, number: exercise.count_in(:composite_page),
+          options: { suppress_solution_if: :even?, note_suppressed_solutions: true }
+        )
       end
     end
     BakeChapterReferences.v1(chapter: chapter, metadata_source: metadata)

--- a/lib/recipes/world-history/bake
+++ b/lib/recipes/world-history/bake
@@ -78,9 +78,10 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :world_history) do |doc|
                                         Kitchen::InjectedQuestionElementEnumerator)
            .each do |exercise|
       if exercise.instance_of?(Kitchen::ExerciseElement)
-        BakeNumberedExercise.v1(exercise: exercise,
-                                number: exercise.count_in(:composite_page),
-                                suppress_solution_if: true)
+        BakeNumberedExercise.v1(
+          exercise: exercise, number: exercise.count_in(:composite_page),
+          options: { suppress_solution_if: true }
+        )
       else
         BakeInjectedExerciseQuestion.v1(question: exercise,
                                         number: exercise.count_in(:composite_page))

--- a/spec/kitchen_spec/directions/bake_numbered_exercise/main_spec.rb
+++ b/spec/kitchen_spec/directions/bake_numbered_exercise/main_spec.rb
@@ -5,8 +5,14 @@ require 'spec_helper'
 RSpec.describe Kitchen::Directions::BakeNumberedExercise do
   it 'calls v1' do
     expect_any_instance_of(Kitchen::Directions::BakeNumberedExercise::V1).to receive(:bake)
-      .with(exercise: 'exercise1', number: '1.1', suppress_solution_if: false, note_suppressed_solutions: false, cases: false, solution_stays_put: false)
-    described_class.v1(exercise: 'exercise1', number: '1.1', suppress_solution_if: false, note_suppressed_solutions: false, cases: false)
+      .with(
+        exercise: 'exercise1', number: '1.1',
+        options: { suppress_solution_if: false, note_suppressed_solutions: false, cases: false, solution_stays_put: false }
+      )
+    described_class.v1(
+      exercise: 'exercise1', number: '1.1',
+      options: {}
+    )
   end
 
   it 'calls bake_solution_v1' do

--- a/spec/kitchen_spec/directions/bake_numbered_exercise/v1_spec.rb
+++ b/spec/kitchen_spec/directions/bake_numbered_exercise/v1_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedExercise do
 
   context 'when solutions are suppressed' do
     it 'works' do
-      described_class.v1(exercise: exercise1, number: '1.1', suppress_solution_if: true)
+      described_class.v1(exercise: exercise1, number: '1.1', options: { suppress_solution_if: true })
 
       expect(exercise1).to match_snapshot_auto
     end
@@ -66,14 +66,14 @@ RSpec.describe Kitchen::Directions::BakeNumberedExercise do
   context 'when even solutions are suppressed' do
     context 'when number is odd' do
       it 'works' do
-        described_class.v1(exercise: exercise1, number: 1, suppress_solution_if: :even?, note_suppressed_solutions: true)
+        described_class.v1(exercise: exercise1, number: 1, options: { suppress_solution_if: :even?, note_suppressed_solutions: true })
         expect(exercise1).to match_snapshot_auto
       end
     end
 
     context 'when number is even' do
       it 'works' do
-        described_class.v1(exercise: exercise1, number: 2, suppress_solution_if: :even?, note_suppressed_solutions: true)
+        described_class.v1(exercise: exercise1, number: 2, options: { suppress_solution_if: :even?, note_suppressed_solutions: true })
         expect(exercise1).to match_snapshot_auto
       end
     end
@@ -101,14 +101,14 @@ RSpec.describe Kitchen::Directions::BakeNumberedExercise do
 
           pantry = exercise1.pantry(name: :genitive_link_text)
           expect(pantry).to receive(:store).with('Ćwiczenia 1.1', { label: 'exercise_id' })
-          described_class.v1(exercise: exercise1, number: '1', cases: true)
+          described_class.v1(exercise: exercise1, number: '1', options: { cases: true })
         end
       end
     end
 
     context 'when exercises remain grouped with solutions' do
       it 'works' do
-        described_class.v1(exercise: exercise1, number: '4', solution_stays_put: true)
+        described_class.v1(exercise: exercise1, number: '4', options: { solution_stays_put: true })
         expect(exercise1).to match_snapshot_auto
       end
     end


### PR DESCRIPTION
inspired by discussion on #74 -- we often control the flow of directions logic by passing in boolean or symbol options. These options aren't otherwise visibly differentiated from the data the direction needs (such as the book or element, a number, etc). This is a possible pattern we could use to help bundle together which parameters are `options` and which aren't, and keep rubocop from dinging a too-long ParameterList.

(we do something similar in [chapter introductions](https://github.com/openstax/cookbook/blob/main/lib/kitchen/directions/bake_chapter_introductions/v2.rb#L5))