### PR TITLE
add careers-marketing to notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `.careers-marketing` to marketing recipe
+
 ## [v1.10.0] - 2022-06-21
 
 * Add support for creating index name term content from name attribute instead of reference if they don't have it for `pl-economics`.

--- a/lib/recipes/marketing/bake
+++ b/lib/recipes/marketing/bake
@@ -107,7 +107,7 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :marketing) do |doc|
     )
   end
 
-  notes = %w[marketing-practice companies-conscience link-to-learning]
+  notes = %w[marketing-practice companies-conscience link-to-learning careers-marketing]
   BakeAutotitledNotes.v1(book: book, classes: notes)
   BakeAutotitledNotes.v1(
     book: book,

--- a/lib/recipes/marketing/locales/en.yml
+++ b/lib/recipes/marketing/locales/en.yml
@@ -4,6 +4,7 @@ en:
     marketing-practice: Marketing in Practice
     companies-conscience: Companies with a Conscience
     link-to-learning: Link to Learning
+    careers-marketing: Careers In Marketing
   eoc:
     knowledge-check: ! '%{number} Knowledge Check'
     chapter-summary: Chapter Summary


### PR DESCRIPTION
Adds careers-marketing to notes to marketing/bake
![Screen Shot 2022-06-24 at 4 32 37 PM](https://user-images.githubusercontent.com/5740972/175695790-c948d056-faf7-42d3-8ed6-33a1753505af.png)

