### PR TITLE
fix section exercises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Change the way of baking title in `BakeChapterSectionExercises`
 * Add answer key to `organic-chemistry`
 * Add `diseases` note to `anatomy`
 * Change `Example` title to `Worked Example` for `organic-chemistry`

--- a/lib/kitchen/directions/bake_chapter_section_exercises/v1.rb
+++ b/lib/kitchen/directions/bake_chapter_section_exercises/v1.rb
@@ -3,7 +3,7 @@
 module Kitchen::Directions::BakeChapterSectionExercises
   class V1
     def bake(chapter:, trash_title:)
-      chapter.pages.each do |page|
+      chapter.non_introduction_pages.each do |page|
         page.search('section.section-exercises').each do |section|
           section.first('h3[data-type="title"]')&.trash if trash_title
           section.wrap(
@@ -13,7 +13,7 @@ module Kitchen::Directions::BakeChapterSectionExercises
 
           section_title = I18n.t(
             :section_exercises,
-            number: "#{chapter.count_in(:book)}.#{section.count_in(:chapter)}")
+            number: "#{chapter.count_in(:book)}.#{page.count_in(:chapter)}")
 
           section.prepend(sibling:
             <<~HTML

--- a/lib/recipes/organic-chemistry/bake
+++ b/lib/recipes/organic-chemistry/bake
@@ -41,8 +41,6 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :organic_chemistry) do |doc|
     end
 
     MoveExercisesToEOC.v1(chapter: chapter, metadata_source: metadata,
-                          klass: 'section-exercises')
-    MoveExercisesToEOC.v1(chapter: chapter, metadata_source: metadata,
                           klass: 'visualizing-chemistry')
     MoveExercisesToEOC.v1(chapter: chapter, metadata_source: metadata,
                           klass: 'additional-problems')
@@ -71,12 +69,14 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :organic_chemistry) do |doc|
     answer_key_inner_container = AnswerKeyInnerContainer.v1(
       chapter: chapter, metadata_source: metadata, append_to: answer_key_wrapper
     )
-    chapter.search('div.os-eos.os-section-exercises-container').each do |section_wrapper|
-      number = "#{chapter.count_in(:book)}.#{section_wrapper.count_in(:chapter)}"
-      Kitchen::Directions::MoveSolutionsFromExerciseSection.v1(
-        chapter: section_wrapper, append_to: answer_key_inner_container,
-        section_class: 'section-exercises', title_number: number
-      )
+    chapter.non_introduction_pages.each do |page|
+      page.search('div.os-eos.os-section-exercises-container').each do |section_wrapper|
+        number = "#{chapter.count_in(:book)}.#{page.count_in(:chapter)}"
+        Kitchen::Directions::MoveSolutionsFromExerciseSection.v1(
+          chapter: section_wrapper, append_to: answer_key_inner_container,
+          section_class: 'section-exercises', title_number: number
+        )
+      end
     end
     %w[visualizing-chemistry additional-problems].each do |klass|
       Kitchen::Directions::MoveSolutionsFromExerciseSection.v1(

--- a/lib/recipes/organic-chemistry/locales/en.yml
+++ b/lib/recipes/organic-chemistry/locales/en.yml
@@ -1,11 +1,12 @@
 en:
   example: Worked Example
+  section_exercises: ! '%{number} Problems'
   notes:
     why-chapter: Why This Chapter?
     something-extra: Something Extra
     working-problems: Working Problems
   eoc:
-    section-exercises: Problems
+    section-exercises: ! '%{number} Problems'
     summary-reactions: Summary Reactions
     visualizing-chemistry: Visualizing Chemistry
     additional-problems: Additional Problems

--- a/spec/kitchen_spec/directions/bake_chapter_section_exercises/v1_spec.rb
+++ b/spec/kitchen_spec/directions/bake_chapter_section_exercises/v1_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Kitchen::Directions::BakeChapterSectionExercises::V1 do
                 </div>
               </div>
             </section>
+          </div>
+          <div data-type="page">
             <section id="sectionId2" class="section-exercises">
               <div data-type="exercise" id="exercise_id2">
                 <div data-type="problem" id="problem_id2">
@@ -80,7 +82,7 @@ RSpec.describe Kitchen::Directions::BakeChapterSectionExercises::V1 do
   context 'without deleting title' do
     it 'bakes & keeps in the title' do
       described_class.new.bake(chapter: book_with_section_exercises.chapters.first, trash_title: false)
-      expect(book_with_section_exercises.chapters.first).to match_normalized_html(expected_result)
+      expect(book_with_section_exercises.chapters.first).to match_snapshot_auto
     end
   end
 
@@ -89,7 +91,7 @@ RSpec.describe Kitchen::Directions::BakeChapterSectionExercises::V1 do
 
     it 'bakes & removes the title' do
       described_class.new.bake(chapter: book_with_section_exercises.chapters.first, trash_title: true)
-      expect(book_with_section_exercises.chapters.first).to match_normalized_html(expected_result)
+      expect(book_with_section_exercises.chapters.first).to match_snapshot_auto
     end
   end
 end

--- a/spec/recipes_spec/books/organic-chemistry/expected_output.xhtml
+++ b/spec/recipes_spec/books/organic-chemistry/expected_output.xhtml
@@ -145,21 +145,16 @@
             </li>
             <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-4">
               <a href="#composite-page-4">
-                <span class="os-text">Problems</span>
+                <span class="os-text">Visualizing Chemistry</span>
               </a>
             </li>
             <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-5">
               <a href="#composite-page-5">
-                <span class="os-text">Visualizing Chemistry</span>
+                <span class="os-text">Additional Problems</span>
               </a>
             </li>
             <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-6">
               <a href="#composite-page-6">
-                <span class="os-text">Additional Problems</span>
-              </a>
-            </li>
-            <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-7">
-              <a href="#composite-page-7">
                 <span class="os-text">Practice Your Scientific Analysis and Reasoning</span>
               </a>
             </li>
@@ -177,15 +172,15 @@
             <span class="os-text">Answer Key</span>
           </a>
           <ol class="os-chapter">
-            <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-8">
-              <a href="#composite-page-8">
+            <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-7">
+              <a href="#composite-page-7">
                 <span class="os-text">Chapter 1</span>
               </a>
             </li>
           </ol>
         </li>
-        <li class="os-toc-index" cnx-archive-shortid="" cnx-archive-uri="composite-page-9">
-          <a href="#composite-page-9">
+        <li class="os-toc-index" cnx-archive-shortid="" cnx-archive-uri="composite-page-8">
+          <a href="#composite-page-8">
             <span class="os-text">Index</span>
           </a>
         </li>
@@ -581,6 +576,75 @@
             <span class="os-divider"> </span>
           </div>
         </div>
+        <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises">
+          <h3 data-type="document-title">
+            <span class="os-text">1.3 Problems</span>
+          </h3>
+          <section data-depth="1" class="section-exercises" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_sect-00001">
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q001" data-injected-from-version="3" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q001" data-tags="book: type:practice assignment-type:reading context-cnxmod:3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-wrapper" class="os-hasSolution">
+                <a class="os-number" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-wrapper-solution">1</a>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stimulus">What is the ground-state electron configuration of each of the following elements:</div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264752" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752">
+                    <div class="os-problem-container">
+                      <a class="problem-letter" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-solution">(a)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">Oxygen
+</div>
+                    </div>
+                  </div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264753" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264753">
+                    <div class="os-problem-container">
+                      <a class="problem-letter" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264753-solution">(b)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">Nitrogen</div>
+                    </div>
+                  </div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264754" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264754">
+                    <div class="os-problem-container">
+                      <a class="problem-letter" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264754-solution">(c)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">Sulfur</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q002" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q002" data-tags="type:practice" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264756-wrapper">
+                <span class="os-number">2</span>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stimulus">How many electrons does each of the following biological trace elements have in its outermost electron shell?</div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264756" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264756">
+                    <div class="os-problem-container">
+                      <a class="problem-letter">(a)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">Magnesium</div>
+                    </div>
+                  </div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264757" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264757">
+                    <div class="os-problem-container">
+                      <a class="problem-letter">(b)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">Cobalt&#x2003;
+</div>
+                    </div>
+                  </div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264758" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264758">
+                    <div class="os-problem-container">
+                      <a class="problem-letter">(c)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">Selenium</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
       </div>
       <div data-type="page" id="page_df442eb4-bdf7-4989-b589-cc221f9fe38a" data-cnxml-to-html-ver="2.9.0" class="chapter-content-module">
         <div data-type="metadata" style="display: none;">
@@ -689,6 +753,78 @@
       <span data-type="media" data-alt="An illustration shows two structures of chloromethane each with a central carbon bonded to three hydrogen atoms and a chlorine atom. The first structure shows 4 pairs of electrons around carbon where one of the pairs is shared with the chlorine atom that shows three pairs of electrons. The second structure shows a central carbon bonded to three hydrogen atoms and a chlorine" data-display="inline" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_12"><img src="../resources/7e0196370fe19a40ea46e87eea31f3939b087a13" data-media-type="image/jpg" alt="An illustration shows two structures of chloromethane each with a central carbon bonded to three hydrogen atoms and a chlorine atom. The first structure shows 4 pairs of electrons around carbon where one of the pairs is shared with the chlorine atom that shows three pairs of electrons. The second structure shows a central carbon bonded to three hydrogen atoms and a chlorine" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_13" /></span>
     </p>
           </div>
+        </div>
+        <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises">
+          <h3 data-type="document-title">
+            <span class="os-text">1.4 Problems</span>
+          </h3>
+          <section data-depth="1" class="section-exercises" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_sect-00001">
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q003" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q003" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264760" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264760" class="os-hasSolution">
+                <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264760-solution">3</a>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">Draw a molecule of chloroform, CHCl3, using solid, wedged, and dashed lines to show its tetrahedral geometry.</div>
+                </div>
+              </div>
+            </div>
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q004" data-injected-from-version="3" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q004" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264762" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264762">
+                <span class="os-number">4</span>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">Convert the following representation of ethane, C<sub>2</sub>H<sub>6</sub>, into a conventional drawing that uses solid, wedged, and dashed lines to indicate tetrahedral geometry around each carbon (black = C, gray = H).<br />
+<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbEVNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--4c094bdc033aba63ca5c621cae316fbdd932efb6/OChem_01_04_006.jpg" alt="An illustration shows the ball-and-stick model of ethanel that shows two methyl groups single bonded to each other. The model shows black balls (carbons) and gray balls (hydrogens)." /></div>
+                </div>
+              </div>
+            </div>
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q005" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q005" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264764" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264764" class="os-hasSolution">
+                <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264764-solution">5</a>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">What are likely formulas for the following substances? This is testing a list and not a MPQ.
+<ol type="a"><li>CCl<sub><span class="magenta-text">?</span></sub></li><li>AlH<sub><span class="magenta-text">?</span></sub></li><li>CH<sub><span class="magenta-text">?</span></sub>Cl<sub>2</sub></li><li>CH<sub>3</sub>SH<sub><span class="magenta-text">?</span></sub></li><li>CH<sub>3</sub>NH<sub><span class="magenta-text">?</span></sub></li></ol></div>
+                </div>
+              </div>
+            </div>
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q006" data-injected-from-version="1" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q006" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="263950" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_263950">
+                <span class="os-number">6</span>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">Write line-bond structures for the following substances, showing all nonbonding electrons:<br />
+(a) CH<sub>3</sub>CH<sub>2</sub>OH, ethanol<br />
+(b)&#x2002;H<sub>2</sub>S, hydrogen sulfide<br />
+(c) CH<sub>3</sub>NH<sub>2</sub>, methylamine<br />
+(d)&#x2002;N(CH<sub>3</sub>)<sub>3</sub>, trimethylamine</div>
+                </div>
+              </div>
+            </div>
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q007" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q007" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="multiple-choice" data-id="264766" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264766" class="os-hasSolution">
+                <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264766-solution">7</a>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">Why can&#x2019;t an organic molecule have the formula C<sub>2</sub>H<sub>7</sub>?</div>
+                  <ol data-type="question-answers" type="a">
+                    <li data-type="question-answer" data-id="818329" data-correctness="1.0">
+                      <div data-type="answer-content">That's not how organic molecules work.</div>
+                    </li>
+                    <li data-type="question-answer" data-id="818330" data-correctness="0.0">
+                      <div data-type="answer-content">It can! This was a trick question.</div>
+                    </li>
+                    <li data-type="question-answer" data-id="818331" data-correctness="0.0">
+                      <div data-type="answer-content">Nobody wants that.</div>
+                    </li>
+                    <li data-type="question-answer" data-id="818332" data-correctness="0.0">
+                      <div data-type="answer-content">It's broken.</div>
+                    </li>
+                  </ol>
+                </div>
+              </div>
+            </div>
+          </section>
         </div>
       </div>
       <div data-type="page" id="page_ba4aa85b-f687-44ef-8ba3-837fba29b9ec" data-cnxml-to-html-ver="2.9.0" class="chapter-content-module">
@@ -864,6 +1000,23 @@
             <span class="os-caption">The carbon&#x2013;carbon bond is formed by &#x3C3; overlap of two <strong><span class="green-text"><em data-effect="italics">sp</em><sup>3</sup> hybrid orbitals</span></strong>.  For clarity, the smaller lobes of the <em data-effect="italics">sp</em><sup>3</sup> hybrid orbitals are not shown.</span>
           </div>
         </div>
+        <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises">
+          <h3 data-type="document-title">
+            <span class="os-text">1.7 Problems</span>
+          </h3>
+          <section data-depth="1" class="section-exercises" id="auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_sect-00001">
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q009" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q009" data-tags="type:practice context-cnxmod:0ee4799c-680b-49c7-ae38-66183e01ddb3" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264768" id="auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_264768" class="os-hasSolution">
+                <a class="os-number" href="#auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_264768-solution">8</a>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">Convert the following molecular model of hexane, a component of gasoline, into a line-bond structure (black = C, gray = H).<br />
+<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbElNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--597a51b3dd191745a4ee85e2b4ef7e444746c81c/OChem_01_07_003.jpg" alt="An illustration shows the ball-and-stick model of hexane. It shows a methyl group bonded to a chain of four methylene groups and then a methyl group. Black balls represent carbon atoms and gray balls represent hydrogens." /></div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
       </div>
       <div data-type="page" id="page_79c00590-caf6-4a04-a729-1554b8e062af" data-cnxml-to-html-ver="2.9.0" class="chapter-content-module">
         <div data-type="metadata" style="display: none;">
@@ -952,6 +1105,33 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
   Like the carbon atoms in ethylene, the carbon atom in formaldehyde is in a double bond and its orbitals are therefore <em data-effect="italics">sp</em><sup>2</sup>-hybridized.
 </p>
           </div>
+        </div>
+        <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises">
+          <h3 data-type="document-title">
+            <span class="os-text">1.8 Problems</span>
+          </h3>
+          <section data-depth="1" class="section-exercises" id="auto_79c00590-caf6-4a04-a729-1554b8e062af_sect-00001">
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q010" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q010" data-tags="type:practice context-cnxmod:79c00590-caf6-4a04-a729-1554b8e062af" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264770" id="auto_79c00590-caf6-4a04-a729-1554b8e062af_264770">
+                <span class="os-number">9</span>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">Draw a line-bond structure for propene, CH<sub>3</sub>CH&#xFF1D;CH<sub>2</sub>. Indicate the hybridization of the orbitals on each carbon, and predict the value of each bond angle.
+</div>
+                </div>
+              </div>
+            </div>
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q012" data-injected-from-version="1" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q012" data-tags="type:practice context-cnxmod:79c00590-caf6-4a04-a729-1554b8e062af" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="263554" id="auto_79c00590-caf6-4a04-a729-1554b8e062af_263554">
+                <span class="os-number">10</span>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">A molecular model of aspirin (acetylsalicylic acid) is shown. Identify the hybridization of the orbitals on each carbon atom in aspirin, and tell which atoms have lone pairs of electrons (black = C, red = O, gray = H).
+<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbFVNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--1288acb9aa6089296d0cc3fbf1437b79d3b934d0/OChem_01_08_004.jpg" alt="An illustration titled &#x201C;Aspirin (acetylsalicylic acid)&#x201D; shows a hexagonal arrangement of six gray balls. The balls are connected through single and double sticks alternatively. Four of these balls are connected to four ivory balls through a stick. The fifth gray ball is connected to another gray ball through a single stick  which in turn is connected to two red balls of which one is through a single stick and the other through 2 sticks. The red ball that is connected to the gray ball through a single stick is linked to an ivory ball through a single stick. The sixth gray ball is attached to a red ball through a single stick which in turn is attached to a gray ball. This gray ball is connected to another gray ball that is connected to 3 other ivory balls through a single stick." /></div>
+                </div>
+              </div>
+            </div>
+          </section>
         </div>
       </div>
       <div data-type="page" id="page_254c405e-e565-450c-a3cd-4bb08e99675d" data-cnxml-to-html-ver="2.9.0" class="chapter-content-module">
@@ -1080,6 +1260,22 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
             <span class="os-divider"> </span>
           </div>
         </div>
+        <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises">
+          <h3 data-type="document-title">
+            <span class="os-text">1.9 Problems</span>
+          </h3>
+          <section data-depth="1" class="section-exercises" id="auto_254c405e-e565-450c-a3cd-4bb08e99675d_sect-00001">
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q013" data-injected-from-version="1" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q013" data-tags="type:practice context-cnxmod:254c405e-e565-450c-a3cd-4bb08e99675d" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="263541" id="auto_254c405e-e565-450c-a3cd-4bb08e99675d_263541">
+                <span class="os-number">11</span>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">Draw a line-bond structure for propyne, CH<sub>3</sub>C&#x2261;CH . Indicate the hybridization of the orbitals on each carbon, and predict a value for each bond angle.</div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
       </div>
       <div data-type="page" id="page_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5" data-cnxml-to-html-ver="2.9.0" class="chapter-content-module">
         <div data-type="metadata" style="display: none;">
@@ -1153,6 +1349,54 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
             <span class="os-title-label">Figure </span>
             <span class="os-number">1.22</span>
           </div>
+        </div>
+        <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises">
+          <h3 data-type="document-title">
+            <span class="os-text">1.10 Problems</span>
+          </h3>
+          <section data-depth="1" class="section-exercises" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_sect-00001">
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q014" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q014" data-tags="type:practice context-cnxmod:0202c868-bb8e-4fd4-a878-dd57c5ba7fe5" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264771-wrapper">
+                <span class="os-number">12</span>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stimulus">Identify all nonbonding lone pairs of electrons in the following molecules, and tell what geometry you expect for each of the indicated atoms.</div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264771" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264771">
+                    <div class="os-problem-container">
+                      <a class="problem-letter">(a)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">The oxygen atom in dimethyl ether, CH<sub>3</sub>&#x2015;O&#x2015;CH<sub>3</sub>.
+</div>
+                    </div>
+                  </div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264772" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264772">
+                    <div class="os-problem-container">
+                      <a class="problem-letter">(b)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">The nitrogen atom in trimethylamine,
+<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbFlNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ff5d5db4844fd5a3a9dfd1c6d79cb6c16b1eda60/OChem_01_10_005.jpg" />
+</div>
+                    </div>
+                  </div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264773" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264773">
+                    <div class="os-problem-container">
+                      <a class="problem-letter">(c)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">The phosphorus atom in phosphine, PH<sub>3</sub>.
+</div>
+                    </div>
+                  </div>
+                  <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264774" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264774">
+                    <div class="os-problem-container">
+                      <a class="problem-letter">(d)</a>
+                      <span class="os-divider"> </span>
+                      <div data-type="question-stem">The sulfur atom in the amino acid methionine.</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
         </div>
       </div>
       <div data-type="page" id="page_3b740daa-b80a-4c64-be10-69247add24b7" data-cnxml-to-html-ver="2.9.0" class="chapter-content-module">
@@ -1290,6 +1534,51 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
               </span>
             </p>
           </div>
+        </div>
+        <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises">
+          <h3 data-type="document-title">
+            <span class="os-text">1.12 Problems</span>
+          </h3>
+          <section data-depth="1" class="section-exercises" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_sect-00002">
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q015" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q015" data-tags="type:practice context-cnxmod:e8416a43-c719-4db7-a87a-1ee7ec8bb673" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264776" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264776" class="os-hasSolution">
+                <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264776-solution">13</a>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">How many hydrogens are bonded to each carbon in the following compounds, and what is the molecular formula of each substance:<br />
+<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbHNNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--8ca93749d30f9d38a6561de7b7a3fbcce53ca4e6/OChem_01_12_006.jpg" alt="" /></div>
+                </div>
+              </div>
+            </div>
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q016" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q016" data-tags="type:practice context-cnxmod:e8416a43-c719-4db7-a87a-1ee7ec8bb673" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264778" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264778" class="os-hasSolution">
+                <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264778-solution">14</a>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stimulus">Propose skeletal structures for compounds that satisfy the following molecular formulas: There is more than one possibility in each case. Also testing list here.</div>
+                  <div data-type="question-stem">
+                    <ol type="a">
+                      <li>C<sub>5</sub>H<sub>12</sub></li>
+                      <li>C<sub>2</sub>H<sub>7</sub>N&#x2003;</li>
+                      <li>C<sub>3</sub>H<sub>6</sub>O&#x2003;</li>
+                      <li>C<sub>4</sub>H<sub>9</sub>Cl</li>
+                    </ol>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q017" data-injected-from-version="1" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q017" data-tags="type:practice context-cnxmod:e8416a43-c719-4db7-a87a-1ee7ec8bb673" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
+              <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="262666" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_262666" class="os-hasSolution">
+                <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_262666-solution">15</a>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">
+                  <div data-type="question-stem">The following molecular model is a representation of <i>para</i>-aminobenzoic acid (PABA), the active ingredient in many sunscreens. Indicate the positions of the multiple bonds, and draw a skeletal structure (black = C, red = O, blue = N, gray = H).
+<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbHdNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--146fd9d6b7d43d66d8a4aa8e6e047293cc236de5/OChem_01_12_007.jpg" alt="An illustration titled &#x201C;para-Aminobenzoic acid (PABA)&#x201D; shows a ball and stick model which shows a hexagonal arrangement of six gray balls connected to each other through a stick. 4 of these gray balls are connected to an ivory ball through a stick. The fifth gray ball is connected to a blue ball which in turn is connected to two ivory balls. The sixth gray ball is connected to another gray ball which in turn is connected to two red balls. One of these red balls is connected to an ivory ball through a stick." />
+</div>
+                </div>
+              </div>
+            </div>
+          </section>
         </div>
         <div data-type="note" class="something-extra" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_note-00001">
           <h3 class="os-title" data-type="title">
@@ -1920,364 +2209,7 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
           </ol>
         </section>
       </div>
-      <div class="os-eoc os-section-exercises-container" data-type="composite-page" data-uuid-key=".section-exercises" id="composite-page-4">
-        <h2 data-type="document-title">
-          <span class="os-text">Problems</span>
-        </h2>
-        <div data-type="metadata" style="display: none;">
-          <h1 data-type="document-title" itemprop="name">Problems</h1>
-          <span data-type="revised" data-value="2022-06-30T16:33:22+00:00"></span>
-          <span data-type="slug" data-value="organic-chemistry"></span>
-          <div class="permissions">
-            <p class="license">
-          Licensed:
-          <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license" target="_blank" rel="noopener nofollow">Creative Commons Attribution-NonCommercial-ShareAlike License</a>
-        </p>
-          </div>
-        </div>
-        <section data-depth="1" class="section-exercises" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_sect-00001">
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q001" data-injected-from-version="3" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q001" data-tags="book: type:practice assignment-type:reading context-cnxmod:3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-wrapper" class="os-hasSolution">
-              <a class="os-number" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-wrapper-solution">1</a>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stimulus">What is the ground-state electron configuration of each of the following elements:</div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264752" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752">
-                  <div class="os-problem-container">
-                    <a class="problem-letter" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-solution">(a)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">Oxygen
-</div>
-                  </div>
-                </div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264753" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264753">
-                  <div class="os-problem-container">
-                    <a class="problem-letter" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264753-solution">(b)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">Nitrogen</div>
-                  </div>
-                </div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264754" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264754">
-                  <div class="os-problem-container">
-                    <a class="problem-letter" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264754-solution">(c)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">Sulfur</div>
-                  </div>
-                </div>
-              </div>
-              <div data-type="question-solution" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-wrapper-solution">
-                <a class="os-number" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-wrapper">1</a>
-                <span class="os-divider">. </span>
-                <div class="os-solution-container">
-                  <div data-type="solution-part" data-solution-source="collaborator" data-solution-type="detailed">
-                    <a class="problem-letter" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-solution">(a)</a>
-                    <span class="os-divider"> </span>
-                    <div class="os-solution-container">
-            1<sub>s</sub><sup>2</sup>
-        </div>
-                  </div>
-                  <div data-type="solution-part" data-solution-source="collaborator" data-solution-type="detailed">
-                    <a class="problem-letter" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264753-solution">(b)</a>
-                    <span class="os-divider"> </span>
-                    <div class="os-solution-container">
-            2p<sub>x</sub><sup>1</sup>
-        </div>
-                  </div>
-                  <div data-type="solution-part" data-solution-source="collaborator" data-solution-type="detailed">
-                    <a class="problem-letter" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264754-solution">(c)</a>
-                    <span class="os-divider"> </span>
-                    <div class="os-solution-container">
-            2p<sub>y</sub><sup>1</sup>
-        </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q002" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q002" data-tags="type:practice" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264756-wrapper">
-              <span class="os-number">2</span>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stimulus">How many electrons does each of the following biological trace elements have in its outermost electron shell?</div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264756" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264756">
-                  <div class="os-problem-container">
-                    <a class="problem-letter">(a)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">Magnesium</div>
-                  </div>
-                </div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264757" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264757">
-                  <div class="os-problem-container">
-                    <a class="problem-letter">(b)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">Cobalt&#x2003;
-</div>
-                  </div>
-                </div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264758" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264758">
-                  <div class="os-problem-container">
-                    <a class="problem-letter">(c)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">Selenium</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section data-depth="1" class="section-exercises" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_sect-00001">
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q003" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q003" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264760" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264760" class="os-hasSolution">
-              <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264760-solution">3</a>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">Draw a molecule of chloroform, CHCl3, using solid, wedged, and dashed lines to show its tetrahedral geometry.</div>
-              </div>
-              <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264760-solution">
-                <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264760">3</a>
-                <span class="os-divider">. </span>
-                <div class="os-solution-container">
-            This is a drawing.
-        </div>
-              </div>
-            </div>
-          </div>
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q004" data-injected-from-version="3" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q004" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264762" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264762">
-              <span class="os-number">4</span>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">Convert the following representation of ethane, C<sub>2</sub>H<sub>6</sub>, into a conventional drawing that uses solid, wedged, and dashed lines to indicate tetrahedral geometry around each carbon (black = C, gray = H).<br />
-<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbEVNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--4c094bdc033aba63ca5c621cae316fbdd932efb6/OChem_01_04_006.jpg" alt="An illustration shows the ball-and-stick model of ethanel that shows two methyl groups single bonded to each other. The model shows black balls (carbons) and gray balls (hydrogens)." /></div>
-              </div>
-            </div>
-          </div>
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q005" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q005" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264764" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264764" class="os-hasSolution">
-              <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264764-solution">5</a>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">What are likely formulas for the following substances? This is testing a list and not a MPQ.
-<ol type="a"><li>CCl<sub><span class="magenta-text">?</span></sub></li><li>AlH<sub><span class="magenta-text">?</span></sub></li><li>CH<sub><span class="magenta-text">?</span></sub>Cl<sub>2</sub></li><li>CH<sub>3</sub>SH<sub><span class="magenta-text">?</span></sub></li><li>CH<sub>3</sub>NH<sub><span class="magenta-text">?</span></sub></li></ol></div>
-              </div>
-              <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264764-solution">
-                <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264764">5</a>
-                <span class="os-divider">. </span>
-                <div class="os-solution-container">
-                  <ol type="a">
-                    <li>C&#x2014;C12</li>
-                    <li>C&#x2014;C12</li>
-                    <li>CH&#x2014;C12</li>
-                    <li>A<sub>1</sub>H10</li>
-                    <li>C&#x2014;C12</li>
-                  </ol>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q006" data-injected-from-version="1" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q006" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="263950" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_263950">
-              <span class="os-number">6</span>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">Write line-bond structures for the following substances, showing all nonbonding electrons:<br />
-(a) CH<sub>3</sub>CH<sub>2</sub>OH, ethanol<br />
-(b)&#x2002;H<sub>2</sub>S, hydrogen sulfide<br />
-(c) CH<sub>3</sub>NH<sub>2</sub>, methylamine<br />
-(d)&#x2002;N(CH<sub>3</sub>)<sub>3</sub>, trimethylamine</div>
-              </div>
-            </div>
-          </div>
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q007" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q007" data-tags="type:practice context-cnxmod:df442eb4-bdf7-4989-b589-cc221f9fe38a" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="multiple-choice" data-id="264766" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264766" class="os-hasSolution">
-              <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264766-solution">7</a>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">Why can&#x2019;t an organic molecule have the formula C<sub>2</sub>H<sub>7</sub>?</div>
-                <ol data-type="question-answers" type="a">
-                  <li data-type="question-answer" data-id="818329" data-correctness="1.0">
-                    <div data-type="answer-content">That's not how organic molecules work.</div>
-                  </li>
-                  <li data-type="question-answer" data-id="818330" data-correctness="0.0">
-                    <div data-type="answer-content">It can! This was a trick question.</div>
-                  </li>
-                  <li data-type="question-answer" data-id="818331" data-correctness="0.0">
-                    <div data-type="answer-content">Nobody wants that.</div>
-                  </li>
-                  <li data-type="question-answer" data-id="818332" data-correctness="0.0">
-                    <div data-type="answer-content">It's broken.</div>
-                  </li>
-                </ol>
-              </div>
-              <div data-type="question-solution" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264766-solution">
-                <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264766">7</a>
-                <span class="os-divider">. </span>
-                <div class="os-solution-container">
-  a
-</div>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section data-depth="1" class="section-exercises" id="auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_sect-00001">
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q009" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q009" data-tags="type:practice context-cnxmod:0ee4799c-680b-49c7-ae38-66183e01ddb3" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264768" id="auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_264768" class="os-hasSolution">
-              <a class="os-number" href="#auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_264768-solution">8</a>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">Convert the following molecular model of hexane, a component of gasoline, into a line-bond structure (black = C, gray = H).<br />
-<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbElNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--597a51b3dd191745a4ee85e2b4ef7e444746c81c/OChem_01_07_003.jpg" alt="An illustration shows the ball-and-stick model of hexane. It shows a methyl group bonded to a chain of four methylene groups and then a methyl group. Black balls represent carbon atoms and gray balls represent hydrogens." /></div>
-              </div>
-              <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_264768-solution">
-                <a class="os-number" href="#auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_264768">8</a>
-                <span class="os-divider">. </span>
-                <div class="os-solution-container">
-            CH<sub>2</sub>CH<sup>2</sup>CH<sub>2</sub>
-        </div>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section data-depth="1" class="section-exercises" id="auto_79c00590-caf6-4a04-a729-1554b8e062af_sect-00001">
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q010" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q010" data-tags="type:practice context-cnxmod:79c00590-caf6-4a04-a729-1554b8e062af" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264770" id="auto_79c00590-caf6-4a04-a729-1554b8e062af_264770">
-              <span class="os-number">9</span>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">Draw a line-bond structure for propene, CH<sub>3</sub>CH&#xFF1D;CH<sub>2</sub>. Indicate the hybridization of the orbitals on each carbon, and predict the value of each bond angle.
-</div>
-              </div>
-            </div>
-          </div>
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q012" data-injected-from-version="1" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q012" data-tags="type:practice context-cnxmod:79c00590-caf6-4a04-a729-1554b8e062af" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="263554" id="auto_79c00590-caf6-4a04-a729-1554b8e062af_263554">
-              <span class="os-number">10</span>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">A molecular model of aspirin (acetylsalicylic acid) is shown. Identify the hybridization of the orbitals on each carbon atom in aspirin, and tell which atoms have lone pairs of electrons (black = C, red = O, gray = H).
-<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbFVNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--1288acb9aa6089296d0cc3fbf1437b79d3b934d0/OChem_01_08_004.jpg" alt="An illustration titled &#x201C;Aspirin (acetylsalicylic acid)&#x201D; shows a hexagonal arrangement of six gray balls. The balls are connected through single and double sticks alternatively. Four of these balls are connected to four ivory balls through a stick. The fifth gray ball is connected to another gray ball through a single stick  which in turn is connected to two red balls of which one is through a single stick and the other through 2 sticks. The red ball that is connected to the gray ball through a single stick is linked to an ivory ball through a single stick. The sixth gray ball is attached to a red ball through a single stick which in turn is attached to a gray ball. This gray ball is connected to another gray ball that is connected to 3 other ivory balls through a single stick." /></div>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section data-depth="1" class="section-exercises" id="auto_254c405e-e565-450c-a3cd-4bb08e99675d_sect-00001">
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q013" data-injected-from-version="1" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q013" data-tags="type:practice context-cnxmod:254c405e-e565-450c-a3cd-4bb08e99675d" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="263541" id="auto_254c405e-e565-450c-a3cd-4bb08e99675d_263541">
-              <span class="os-number">11</span>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">Draw a line-bond structure for propyne, CH<sub>3</sub>C&#x2261;CH . Indicate the hybridization of the orbitals on each carbon, and predict a value for each bond angle.</div>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section data-depth="1" class="section-exercises" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_sect-00001">
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q014" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q014" data-tags="type:practice context-cnxmod:0202c868-bb8e-4fd4-a878-dd57c5ba7fe5" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264771-wrapper">
-              <span class="os-number">12</span>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stimulus">Identify all nonbonding lone pairs of electrons in the following molecules, and tell what geometry you expect for each of the indicated atoms.</div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264771" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264771">
-                  <div class="os-problem-container">
-                    <a class="problem-letter">(a)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">The oxygen atom in dimethyl ether, CH<sub>3</sub>&#x2015;O&#x2015;CH<sub>3</sub>.
-</div>
-                  </div>
-                </div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264772" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264772">
-                  <div class="os-problem-container">
-                    <a class="problem-letter">(b)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">The nitrogen atom in trimethylamine,
-<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbFlNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ff5d5db4844fd5a3a9dfd1c6d79cb6c16b1eda60/OChem_01_10_005.jpg" />
-</div>
-                  </div>
-                </div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264773" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264773">
-                  <div class="os-problem-container">
-                    <a class="problem-letter">(c)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">The phosphorus atom in phosphine, PH<sub>3</sub>.
-</div>
-                  </div>
-                </div>
-                <div data-type="alphabetical-question-multipart" data-is-answer-order-important="false" data-formats="free-response" data-id="264774" id="auto_0202c868-bb8e-4fd4-a878-dd57c5ba7fe5_264774">
-                  <div class="os-problem-container">
-                    <a class="problem-letter">(d)</a>
-                    <span class="os-divider"> </span>
-                    <div data-type="question-stem">The sulfur atom in the amino acid methionine.</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section data-depth="1" class="section-exercises" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_sect-00002">
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q015" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q015" data-tags="type:practice context-cnxmod:e8416a43-c719-4db7-a87a-1ee7ec8bb673" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264776" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264776" class="os-hasSolution">
-              <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264776-solution">13</a>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">How many hydrogens are bonded to each carbon in the following compounds, and what is the molecular formula of each substance:<br />
-<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbHNNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--8ca93749d30f9d38a6561de7b7a3fbcce53ca4e6/OChem_01_12_006.jpg" alt="" /></div>
-              </div>
-              <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264776-solution">
-                <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264776">13</a>
-                <span class="os-divider">. </span>
-                <div class="os-solution-container">
-            Bob Loblaw
-        </div>
-              </div>
-            </div>
-          </div>
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q016" data-injected-from-version="2" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q016" data-tags="type:practice context-cnxmod:e8416a43-c719-4db7-a87a-1ee7ec8bb673" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="264778" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264778" class="os-hasSolution">
-              <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264778-solution">14</a>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stimulus">Propose skeletal structures for compounds that satisfy the following molecular formulas: There is more than one possibility in each case. Also testing list here.</div>
-                <div data-type="question-stem">
-                  <ol type="a">
-                    <li>C<sub>5</sub>H<sub>12</sub></li>
-                    <li>C<sub>2</sub>H<sub>7</sub>N&#x2003;</li>
-                    <li>C<sub>3</sub>H<sub>6</sub>O&#x2003;</li>
-                    <li>C<sub>4</sub>H<sub>9</sub>Cl</li>
-                  </ol>
-                </div>
-              </div>
-              <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264778-solution">
-                <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264778">14</a>
-                <span class="os-divider">. </span>
-                <div class="os-solution-container">
-            Here are four answers.
-        </div>
-              </div>
-            </div>
-          </div>
-          <div data-type="injected-exercise" data-injected-from-nickname="OrgChem_C01_Q017" data-injected-from-version="1" data-injected-from-url="https://exercises.openstax.org/api/exercises?q=nickname:OrgChem_C01_Q017" data-tags="type:practice context-cnxmod:e8416a43-c719-4db7-a87a-1ee7ec8bb673" data-is-vocab="false" data-question-count="1" data-is-multipart="False">
-            <div data-type="exercise-question" data-is-answer-order-important="false" data-formats="free-response" data-id="262666" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_262666" class="os-hasSolution">
-              <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_262666-solution">15</a>
-              <span class="os-divider">. </span>
-              <div class="os-problem-container">
-                <div data-type="question-stem">The following molecular model is a representation of <i>para</i>-aminobenzoic acid (PABA), the active ingredient in many sunscreens. Indicate the positions of the multiple bonds, and draw a skeletal structure (black = C, red = O, blue = N, gray = H).
-<img src="https://exercises.openstax.org/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBbHdNIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--146fd9d6b7d43d66d8a4aa8e6e047293cc236de5/OChem_01_12_007.jpg" alt="An illustration titled &#x201C;para-Aminobenzoic acid (PABA)&#x201D; shows a ball and stick model which shows a hexagonal arrangement of six gray balls connected to each other through a stick. 4 of these gray balls are connected to an ivory ball through a stick. The fifth gray ball is connected to a blue ball which in turn is connected to two ivory balls. The sixth gray ball is connected to another gray ball which in turn is connected to two red balls. One of these red balls is connected to an ivory ball through a stick." />
-</div>
-              </div>
-              <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_262666-solution">
-                <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_262666">15</a>
-                <span class="os-divider">. </span>
-                <div class="os-solution-container">
-            bob loblaw
-        </div>
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
-      <div class="os-eoc os-visualizing-chemistry-container" data-type="composite-page" data-uuid-key=".visualizing-chemistry" id="composite-page-5">
+      <div class="os-eoc os-visualizing-chemistry-container" data-type="composite-page" data-uuid-key=".visualizing-chemistry" id="composite-page-4">
         <h2 data-type="document-title">
           <span class="os-text">Visualizing Chemistry</span>
         </h2>
@@ -2326,7 +2258,7 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
           </div>
         </section>
       </div>
-      <div class="os-eoc os-additional-problems-container" data-type="composite-page" data-uuid-key=".additional-problems" id="composite-page-6">
+      <div class="os-eoc os-additional-problems-container" data-type="composite-page" data-uuid-key=".additional-problems" id="composite-page-5">
         <h2 data-type="document-title">
           <span class="os-text">Additional Problems</span>
         </h2>
@@ -2608,7 +2540,7 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
           </div>
         </section>
       </div>
-      <div class="os-eoc os-practice-scientific-container" data-type="composite-page" data-uuid-key=".practice-scientific" id="composite-page-7">
+      <div class="os-eoc os-practice-scientific-container" data-type="composite-page" data-uuid-key=".practice-scientific" id="composite-page-6">
         <h2 data-type="document-title">
           <span class="os-text">Practice Your Scientific Analysis and Reasoning</span>
         </h2>
@@ -2688,7 +2620,7 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
         </p>
         </div>
       </div>
-      <div class="os-eob os-solutions-container" data-type="composite-page" data-uuid-key=".solutions1" id="composite-page-8">
+      <div class="os-eob os-solutions-container" data-type="composite-page" data-uuid-key=".solutions1" id="composite-page-7">
         <h2 data-type="document-title">
           <span class="os-text">Chapter 1</span>
         </h2>
@@ -2701,6 +2633,108 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
           Licensed:
           <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license" target="_blank" rel="noopener nofollow">Creative Commons Attribution-NonCommercial-ShareAlike License</a>
         </p>
+          </div>
+        </div>
+        <div class="os-solution-area">
+          <h3 data-type="title">
+            <span class="os-title-label">1.3 Problems</span>
+          </h3>
+          <div data-type="question-solution" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-wrapper-solution">
+            <a class="os-number" href="#auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-wrapper">1</a>
+            <span class="os-divider">. </span>
+            <div class="os-solution-container">
+              <div data-type="solution-part" data-solution-source="collaborator" data-solution-type="detailed">
+                <a class="problem-letter" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264752-solution">(a)</a>
+                <span class="os-divider"> </span>
+                <div class="os-solution-container">
+            1<sub>s</sub><sup>2</sup>
+        </div>
+              </div>
+              <div data-type="solution-part" data-solution-source="collaborator" data-solution-type="detailed">
+                <a class="problem-letter" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264753-solution">(b)</a>
+                <span class="os-divider"> </span>
+                <div class="os-solution-container">
+            2p<sub>x</sub><sup>1</sup>
+        </div>
+              </div>
+              <div data-type="solution-part" data-solution-source="collaborator" data-solution-type="detailed">
+                <a class="problem-letter" id="auto_3a2b4db9-a3a8-4c68-a8bd-baa4ba7bd43c_264754-solution">(c)</a>
+                <span class="os-divider"> </span>
+                <div class="os-solution-container">
+            2p<sub>y</sub><sup>1</sup>
+        </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="os-solution-area">
+          <h3 data-type="title">
+            <span class="os-title-label">1.4 Problems</span>
+          </h3>
+          <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264760-solution">
+            <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264760">3</a>
+            <span class="os-divider">. </span>
+            <div class="os-solution-container">
+            This is a drawing.
+        </div>
+          </div>
+          <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264764-solution">
+            <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264764">5</a>
+            <span class="os-divider">. </span>
+            <div class="os-solution-container">
+              <ol type="a">
+                <li>C&#x2014;C12</li>
+                <li>C&#x2014;C12</li>
+                <li>CH&#x2014;C12</li>
+                <li>A<sub>1</sub>H10</li>
+                <li>C&#x2014;C12</li>
+              </ol>
+            </div>
+          </div>
+          <div data-type="question-solution" id="auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264766-solution">
+            <a class="os-number" href="#auto_df442eb4-bdf7-4989-b589-cc221f9fe38a_264766">7</a>
+            <span class="os-divider">. </span>
+            <div class="os-solution-container">
+  a
+</div>
+          </div>
+        </div>
+        <div class="os-solution-area">
+          <h3 data-type="title">
+            <span class="os-title-label">1.7 Problems</span>
+          </h3>
+          <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_264768-solution">
+            <a class="os-number" href="#auto_0ee4799c-680b-49c7-ae38-66183e01ddb3_264768">8</a>
+            <span class="os-divider">. </span>
+            <div class="os-solution-container">
+            CH<sub>2</sub>CH<sup>2</sup>CH<sub>2</sub>
+        </div>
+          </div>
+        </div>
+        <div class="os-solution-area">
+          <h3 data-type="title">
+            <span class="os-title-label">1.12 Problems</span>
+          </h3>
+          <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264776-solution">
+            <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264776">13</a>
+            <span class="os-divider">. </span>
+            <div class="os-solution-container">
+            Bob Loblaw
+        </div>
+          </div>
+          <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264778-solution">
+            <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_264778">14</a>
+            <span class="os-divider">. </span>
+            <div class="os-solution-container">
+            Here are four answers.
+        </div>
+          </div>
+          <div data-type="question-solution" data-solution-source="collaborator" data-solution-type="detailed" id="auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_262666-solution">
+            <a class="os-number" href="#auto_e8416a43-c719-4db7-a87a-1ee7ec8bb673_262666">15</a>
+            <span class="os-divider">. </span>
+            <div class="os-solution-container">
+            bob loblaw
+        </div>
           </div>
         </div>
         <div class="os-solution-area">
@@ -2804,7 +2838,7 @@ To complete the structure of <span data-type="term" class="no-emphasis" id="auto
         </div>
       </div>
     </div>
-    <div class="os-eob os-index-container" data-type="composite-page" data-uuid-key="index" id="composite-page-9">
+    <div class="os-eob os-index-container" data-type="composite-page" data-uuid-key="index" id="composite-page-8">
       <h1 data-type="document-title">
         <span class="os-text">Index</span>
       </h1>

--- a/spec/snapshots/Kitchen_Directions_BakeChapterSectionExercises_V1_with_title_deleted_bakes_removes_the_title.snap
+++ b/spec/snapshots/Kitchen_Directions_BakeChapterSectionExercises_V1_with_title_deleted_bakes_removes_the_title.snap
@@ -1,0 +1,33 @@
+<div data-type="chapter">
+  <div data-type="page">
+    <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises"><h3 data-type="document-title">
+  <span class="os-text">Section 1.1 Exercises</span>
+</h3>
+<section id="sectionId1" class="section-exercises">
+      
+      <div data-type="exercise" id="exercise_id1">
+        <div data-type="problem" id="problem_id1">
+          <p>exercise content 1</p>
+        </div>
+        <div data-type="solution" id="solution_id1">
+          <p>Solution content</p>
+        </div>
+      </div>
+    </section></div>
+  </div>
+  <div data-type="page">
+    <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises"><h3 data-type="document-title">
+  <span class="os-text">Section 1.2 Exercises</span>
+</h3>
+<section id="sectionId2" class="section-exercises">
+      <div data-type="exercise" id="exercise_id2">
+        <div data-type="problem" id="problem_id2">
+          <p>exercise content 2</p>
+        </div>
+        <div data-type="solution" id="solution_id2">
+          <p>Solution content</p>
+        </div>
+      </div>
+    </section></div>
+  </div>
+</div>

--- a/spec/snapshots/Kitchen_Directions_BakeChapterSectionExercises_V1_without_deleting_title_bakes_keeps_in_the_title.snap
+++ b/spec/snapshots/Kitchen_Directions_BakeChapterSectionExercises_V1_without_deleting_title_bakes_keeps_in_the_title.snap
@@ -1,0 +1,33 @@
+<div data-type="chapter">
+  <div data-type="page">
+    <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises"><h3 data-type="document-title">
+  <span class="os-text">Section 1.1 Exercises</span>
+</h3>
+<section id="sectionId1" class="section-exercises">
+      <h3 data-type="title">A title</h3>
+      <div data-type="exercise" id="exercise_id1">
+        <div data-type="problem" id="problem_id1">
+          <p>exercise content 1</p>
+        </div>
+        <div data-type="solution" id="solution_id1">
+          <p>Solution content</p>
+        </div>
+      </div>
+    </section></div>
+  </div>
+  <div data-type="page">
+    <div class="os-eos os-section-exercises-container" data-uuid-key=".section-exercises"><h3 data-type="document-title">
+  <span class="os-text">Section 1.2 Exercises</span>
+</h3>
+<section id="sectionId2" class="section-exercises">
+      <div data-type="exercise" id="exercise_id2">
+        <div data-type="problem" id="problem_id2">
+          <p>exercise content 2</p>
+        </div>
+        <div data-type="solution" id="solution_id2">
+          <p>Solution content</p>
+        </div>
+      </div>
+    </section></div>
+  </div>
+</div>


### PR DESCRIPTION
- Change the way of baking title in Section Exercises. Number should be consistant with page number, not counting `.section-exercises`, because such section might not exists in all pages.
- Same problem in Answer Key titles.