### PR TITLE
add dummy locale for non-english books

### DIFF
--- a/lib/recipes/dummy/bake
+++ b/lib/recipes/dummy/bake
@@ -2,6 +2,8 @@
 
 require_relative '../recipes_helper'
 
+I18n.locale = 'zz'
+
 recipe = Kitchen::BookRecipe.new(book_short_name: :dummy) do |doc|
   include Kitchen::Directions
 

--- a/lib/recipes/dummy/locales/zz.yml
+++ b/lib/recipes/dummy/locales/zz.yml
@@ -1,0 +1,3 @@
+# The dummy recipe does not actually inject text but cookbook requires a locale file
+zz:
+  test: Just a placeholder


### PR DESCRIPTION
CNX user books are written in many languages and cookbook requires a locale