### PR TITLE
have tests fail immediately if kitchen tests fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Update CI to fail right away if kitchen tests fail
 * Revert adding `div` wrapper to `BakeEquations`
 
 ## [v1.20.0] - 2022-10-21

--- a/docker/ci
+++ b/docker/ci
@@ -12,4 +12,4 @@ docker run $CI_ENV \
            -v $DIR/..:/code \
            -w /code \
            openstax/cookbook.ci:latest \
-           /bin/bash -c "bundle config path vendor/bundle; bundle install; bundle exec rspec spec/kitchen_spec/ || exit; bundle exec rspec spec/recipes_spec/"
+           /bin/bash -c "bundle config path vendor/bundle && bundle install && bundle exec rspec spec/kitchen_spec/ && bundle exec rspec spec/recipes_spec/"

--- a/docker/ci
+++ b/docker/ci
@@ -12,4 +12,4 @@ docker run $CI_ENV \
            -v $DIR/..:/code \
            -w /code \
            openstax/cookbook.ci:latest \
-           /bin/bash -c "bundle config path vendor/bundle; bundle install; bundle exec rspec"
+           /bin/bash -c "bundle config path vendor/bundle; bundle install; bundle exec rspec spec/kitchen_spec/ || exit; bundle exec rspec spec/recipes_spec/"


### PR DESCRIPTION
If there's a failure in the kitchen tests, recipe tests won't run. This only affects CI runs on GitHub.