### PR TITLE
note title bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Bugfix `BakeUnclassifiedNotes` so title's id isn't copied if empty
 * Add `remove_unused_snapshots` script
 * Move `aside` elements outside of `spans` in captions (block level element cannot be inside an inline element)
 * Bake `dedication-page` note in `organic-chemistry`

--- a/lib/kitchen/directions/bake_notes/bake_unclassified_notes.rb
+++ b/lib/kitchen/directions/bake_notes/bake_unclassified_notes.rb
@@ -17,10 +17,12 @@ module Kitchen
         title = note.title&.cut
         return unless title
 
+        title_id = " id=\"#{title[:id]}\"" if title[:id]
+
         note.prepend(child:
           <<~HTML
             <h3 class="os-title" data-type="title">
-              <span class="os-title-label" data-type="" id="#{title[:id]}">#{title.children}</span>
+              <span class="os-title-label" data-type=""#{title_id}>#{title.children}</span>
             </h3>
           HTML
         )

--- a/spec/kitchen_spec/directions/bake_notes/bake_unclassified_notes_spec.rb
+++ b/spec/kitchen_spec/directions/bake_notes/bake_unclassified_notes_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Kitchen::Directions::BakeUnclassifiedNotes do
             <div data-type="title" id="titleId">note <em data-effect="italics">title</em></div>
             <p>content</p>
           </div>
+          <div data-type="note" id="titlednote">
+            <div data-type="title">note <em data-effect="italics"> without title id</em></div>
+            <p>content</p>
+          </div>
           <div data-type="note" id="untitlednote">
             <p>content</p>
           </div>

--- a/spec/snapshots/Kitchen_Directions_BakeUnclassifiedNotes_bakes.snap
+++ b/spec/snapshots/Kitchen_Directions_BakeUnclassifiedNotes_bakes.snap
@@ -6,6 +6,13 @@
   
   <p>content</p>
 </div></div>
+<div data-type="note" id="titlednote"><h3 class="os-title" data-type="title">
+  <span class="os-title-label" data-type="">note <em data-effect="italics"> without title id</em></span>
+</h3>
+<div class="os-note-body">
+  
+  <p>content</p>
+</div></div>
 <div data-type="note" id="untitlednote"><div class="os-note-body">
   <p>content</p>
 </div></div>


### PR DESCRIPTION
[#4941](https://github.com/openstax/cnx-recipes/issues/4941)

Fixes empty ids popping up in notes without title ids!