### PR TITLE
Remove dependence on id when creating iframe links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Create Recipe Nursing Series
 * Remove numbering from figures without id
+* Remove dependence on element id when creating rex links
 
 ## [v1.25.0] - 2023-02-24
 

--- a/lib/kitchen/directions/bake_iframes/v1.rb
+++ b/lib/kitchen/directions/bake_iframes/v1.rb
@@ -12,9 +12,9 @@ module Kitchen::Directions::BakeIframes
 
         iframe_link = \
           begin
-            iframe.parent.rex_link
+            iframe.rex_link
           rescue StandardError
-            warn "Unable to find rex link for iframe with parent #{iframe.parent}"
+            warn "Unable to find rex link for iframe #{iframe}"
             iframe[:src]
           end
         iframe.wrap('<div class="os-has-iframe" data-type="switch">')

--- a/lib/kitchen/directions/bake_iframes/v1.rb
+++ b/lib/kitchen/directions/bake_iframes/v1.rb
@@ -14,7 +14,7 @@ module Kitchen::Directions::BakeIframes
           begin
             iframe.parent.rex_link
           rescue StandardError
-            warn "Unable to find rex link for iframe with parent id=#{iframe.parent.id}"
+            warn "Unable to find rex link for iframe with parent #{iframe.parent}"
             iframe[:src]
           end
         iframe.wrap('<div class="os-has-iframe" data-type="switch">')

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -849,14 +849,16 @@ module Kitchen
     end
 
     def rex_link
-      raise 'Cannot create rex link to an element without an ID' unless id
+      self[:'data-is-for-rex-linking'] = "true"
 
       element_with_ancestors = document.book.chapters.search_with(
         Kitchen::PageElementEnumerator, Kitchen::CompositePageElementEnumerator
-      ).search("##{id}").first
+      ).search('[data-is-for-rex-linking="true"]').first
+
+      remove_attribute('data-is-for-rex-linking')
 
       unless element_with_ancestors
-        raise "Cannot create rex link to element with ID #{id} - needs ancestors of both types chapter & page/composite_page"
+        raise "Cannot create rex link to element #{self} - needs ancestors of both types chapter & page/composite_page"
       end
 
       book_slug = document.search('span[data-type="slug"]').first[:'data-value']

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -849,7 +849,7 @@ module Kitchen
     end
 
     def rex_link
-      self[:'data-is-for-rex-linking'] = "true"
+      self[:'data-is-for-rex-linking'] = 'true'
 
       element_with_ancestors = document.book.chapters.search_with(
         Kitchen::PageElementEnumerator, Kitchen::CompositePageElementEnumerator

--- a/spec/kitchen_spec/directions/bake_iframes/v1_spec.rb
+++ b/spec/kitchen_spec/directions/bake_iframes/v1_spec.rb
@@ -102,16 +102,9 @@ RSpec.describe Kitchen::Directions::BakeIframes::V1 do
 
     it 'warns when rex link can\'t be made - no slug' do
       expect(Warning).to receive(:warn).with(
-        "Unable to find rex link for iframe with parent id=1234\n"
+        /Unable to find rex link for iframe with parent[^>]+id="1234"/
       )
       described_class.new.bake(book: book_with_iframe_no_slug)
-    end
-
-    it 'warns when rex link can\'t be made - no id' do
-      expect(Warning).to receive(:warn).with(
-        "Unable to find rex link for iframe with parent id=\n"
-      )
-      described_class.new.bake(book: book_with_iframe_no_id_on_media)
     end
   end
 end

--- a/spec/kitchen_spec/directions/bake_iframes/v1_spec.rb
+++ b/spec/kitchen_spec/directions/bake_iframes/v1_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Kitchen::Directions::BakeIframes::V1 do
 
     it 'warns when rex link can\'t be made - no slug' do
       expect(Warning).to receive(:warn).with(
-        /Unable to find rex link for iframe with parent[^>]+id="1234"/
+        /Unable to find rex link for iframe <iframe/
       )
       described_class.new.bake(book: book_with_iframe_no_slug)
     end

--- a/spec/kitchen_spec/element_base_spec.rb
+++ b/spec/kitchen_spec/element_base_spec.rb
@@ -657,13 +657,9 @@ RSpec.describe Kitchen::ElementBase do
         eq('https://openstax.org/books/test-book-slug/pages/2-summary-or-something')
     end
 
-    it 'raises error for element without id' do
-      expect { book_rex_linkable.chapters.first.rex_link }.to raise_error('Cannot create rex link to an element without an ID')
-    end
-
     it 'raises error when ancestors can\'t be found' do
       expect { book_rex_linkable.pages('$#not-in-chapter').first.rex_link }.to \
-        raise_error('Cannot create rex link to element with ID not-in-chapter - needs ancestors of both types chapter & page/composite_page')
+        raise_error(/Cannot create rex link to element[^>]+id="not-in-chapter"/)
     end
   end
 


### PR DESCRIPTION
Temporarily add `data-is-for-rex-linking="true"` attribute to uniquely identify the element the link is generated from.

This approach assumes there is no concurrency. If there were, we would need a better solution or a more universally unique value for the attribute.

Use `data-is-for-rex-linking` to get `element_with_ancestors`, then remove the attribute.

Also - make the warnings print the element instead of its id (since it may not have one) and update tests to account for this. 