### PR TITLE
change <img> height & width to data-height & data-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Change `BakeImages` height & width to `data-height` and `data-width`
 * Add additional EOC sections to `hs-college-success`
 * Support `<img>` markup:
   * Add `Kitchen` infrastructure to allow passing in resources to `Oven#bake`

--- a/lib/kitchen/directions/bake_images.rb
+++ b/lib/kitchen/directions/bake_images.rb
@@ -17,8 +17,8 @@ module Kitchen
               else
                 1
               end
-            image[:width] = (img_json[:width].to_i * scale).floor
-            image[:height] = (img_json[:height].to_i * scale).floor
+            image[:'data-width'] = (img_json[:width].to_i * scale).floor
+            image[:'data-height'] = (img_json[:height].to_i * scale).floor
           else
             warn("Could not find resource for image with src #{image[:src]}") unless ENV['NO_IMAGE_RESOURCES']
           end

--- a/spec/kitchen_spec/directions/bake_images_spec.rb
+++ b/spec/kitchen_spec/directions/bake_images_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe Kitchen::Directions::BakeImages do
     expect(book.body).to match_normalized_html(
       <<~HTML
         <body>
-          <img src="../resources/abcdef" data-media-type="image/jpeg" alt="an image" data-sm="blah" width="1028" height="464"/>
-          <img src="../resources/123456" data-media-type="image/jpeg" alt="an image" data-sm="blah2" width="241" height="111"/>
-          <img src="../resources/xyzqrs" data-media-type="image/jpeg" alt="an image" data-sm="blah3" width="49" height="90"/>
+          <img src="../resources/abcdef" data-media-type="image/jpeg" alt="an image" data-sm="blah" data-width="1028" data-height="464"/>
+          <img src="../resources/123456" data-media-type="image/jpeg" alt="an image" data-sm="blah2" data-width="241" data-height="111" width="241"/>
+          <img src="../resources/xyzqrs" data-media-type="image/jpeg" alt="an image" data-sm="blah3" data-width="49" data-height="90" height="90"/>
         </body>
       HTML
     )

--- a/spec/recipes_spec/books/dummy/expected_output.xhtml
+++ b/spec/recipes_spec/books/dummy/expected_output.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
   <body>
     <div class="test123">Hello, world!</div>
-    <img src="../resources/abc012def345.json" data-media-type="image/jpeg" alt="alt text" id="auto_1234567890" width="1028" height="464" />
+    <img src="../resources/abc012def345.json" data-media-type="image/jpeg" alt="alt text" id="auto_1234567890" data-width="1028" data-height="464" />
   </body>
 </html>


### PR DESCRIPTION
new specifications: Move data out of `width` and `height` attributes, which impact content display, into the neutral `data-width` and `data-height`.

Final fix pending discussion with REX.