### PR TITLE
bake figures in preface (all books)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Bake figures in preface in `all books`
 * Enable `detailed solution` in `python`
 
 ## [1.33.0] - 2023-06-15

--- a/archived_recipes/additive-manufacturing/bake
+++ b/archived_recipes/additive-manufacturing/bake
@@ -18,13 +18,6 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :additive_manufacturing) do |d
   BakeUnnumberedFigure.v1(book: book)
   BakePreface.v1(book: book)
 
-  book.pages('$.preface').each do |page|
-    page.figures(only: :figure_to_number?).each do |figure|
-      BakeFigure.v1(figure: figure,
-                    number: figure.count_in(:page).to_s)
-    end
-  end
-
   BakeChapterTitle.v1(book: book)
   BakeChapterIntroductions.v2(
     book: book, options: {

--- a/lib/kitchen/directions/bake_preface/v1.rb
+++ b/lib/kitchen/directions/bake_preface/v1.rb
@@ -13,6 +13,10 @@ module Kitchen::Directions::BakePreface
           )
           title.name = title_element
         end
+        page.figures(only: :figure_to_number?).each do |figure|
+          Kitchen::Directions::BakeFigure.v1(figure: figure,
+                                             number: figure.count_in(:page).to_s)
+        end
       end
     end
   end

--- a/lib/recipes/accounting/bake
+++ b/lib/recipes/accounting/bake
@@ -19,12 +19,7 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :accounting) do |doc, resource
 
   BakeImages.v1(book: book, resources: resources)
   BakePreface.v1(book: book)
-  book.pages('$.preface').each do |page|
-    page.figures(only: :figure_to_number?).each do |figure|
-      BakeFigure.v1(figure: figure,
-                    number: figure.count_in(:page).to_s)
-    end
-  end
+
   BakeUnnumberedFigure.v1(book: book)
   BakeUnnumberedTables.v1(book: book)
 

--- a/lib/recipes/astronomy/bake
+++ b/lib/recipes/astronomy/bake
@@ -18,14 +18,6 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :astronomy) do |doc, resources
   BakeChapterTitle.v1(book: book)
   BakeChapterIntroductions.v1(book: book)
 
-  preface = book.pages('$.preface').first
-  preface.figures(only: :figure_to_number?).each do |figure|
-    BakeFigure.v1(
-      figure: figure,
-      number: figure.count_in(:page)
-    )
-  end
-
   BakeAutotitledNotes.v1(
     book: book,
     classes: %w[

--- a/lib/recipes/college-success/collegesuccess_recipe.rb
+++ b/lib/recipes/college-success/collegesuccess_recipe.rb
@@ -14,12 +14,7 @@ COLLEGESUCCESS_RECIPE = Kitchen::BookRecipe.new(
   BakeImages.v1(book: book, resources: resources)
   BakeUnnumberedFigure.v1(book: book)
   BakePreface.v1(book: book)
-  book.pages('$.preface').each do |page|
-    page.figures(only: :figure_to_number?).each do |figure|
-      BakeFigure.v1(figure: figure,
-                    number: figure.count_in(:page).to_s)
-    end
-  end
+
   BakeChapterTitle.v1(book: book)
   BakeChapterIntroductions.v1(book: book)
 

--- a/lib/recipes/computer-science/bake
+++ b/lib/recipes/computer-science/bake
@@ -96,12 +96,6 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :computer_science) do |doc, re
     end
   end
 
-  book.pages('$.preface').each do |page|
-    page.figures(only: :figure_to_number?).each do |figure|
-      BakeFigure.v1(figure: figure, number: figure.count_in(:page))
-    end
-  end
-
   book.pages('$.appendix').each do |page|
     appendix_letter = [*('A'..'Z')][page.count_in(:book) - 1]
 

--- a/lib/recipes/contemporary-math/bake
+++ b/lib/recipes/contemporary-math/bake
@@ -16,13 +16,6 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :contemporary_math) do |doc, r
   BakeImages.v1(book: book, resources: resources)
   BakePreface.v1(book: book)
 
-  book.pages('$.preface').each do |page|
-    page.figures(only: :figure_to_number?).each do |figure|
-      BakeFigure.v1(figure: figure,
-                    number: figure.count_in(:page)).to_s
-    end
-  end
-
   BakeChapterIntroductions.v1(book: book)
   BakeChapterTitle.v1(book: book)
   AddInjectedExerciseId.v1(book: book)

--- a/lib/recipes/marketing/bake
+++ b/lib/recipes/marketing/bake
@@ -23,11 +23,6 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :marketing) do |doc, resources
   BakePreface.v1(book: book)
 
   book.pages('$.preface').each do |page|
-    page.figures(only: :figure_to_number?).each do |figure|
-      BakeFigure.v1(figure: figure,
-                    number: figure.count_in(:page)).to_s
-    end
-
     page.tables('$:not(.unnumbered)').each do |table|
       BakeNumberedTable.v1(table: table,
                            number: table.count_in(:page).to_s)

--- a/lib/recipes/nursing-internal/bake
+++ b/lib/recipes/nursing-internal/bake
@@ -18,12 +18,7 @@ recipe = Kitchen::BookRecipe.new(book_short_name: :nursing_internal) do |doc, re
   # Your recipe code goes here
   BakeImages.v1(book: book, resources: resources)
   BakePreface.v1(book: book)
-  book.pages('$.preface').each do |page|
-    page.figures(only: :figure_to_number?).each do |figure|
-      BakeFigure.v1(figure: figure,
-                    number: figure.count_in(:page)).to_s
-    end
-  end
+
   BakeUnnumberedFigure.v1(book: book)
   BakeUnnumberedTables.v1(book: book)
 

--- a/spec/kitchen_spec/directions/bake_preface/v1_spec.rb
+++ b/spec/kitchen_spec/directions/bake_preface/v1_spec.rb
@@ -18,6 +18,33 @@ RSpec.describe Kitchen::Directions::BakePreface::V1 do
           <div data-type="metadata">
             <div data-type="document-title">Preface</div>
           </div>
+          <figure id="someId">
+            <figcaption>Solid <em>carbon</em> dioxide sublimes ...</figcaption>
+            <div data-type='title'>This Is A Title</div>
+            <span data-type="media" id="otherId" data-alt="This figure shows pieces of a ...">
+            </span>
+          </figure>
+          <div data-type="abstract" id="abcde">abstract</div>
+        </div>
+
+        <div data-type="page" class="preface">
+          <div data-type="document-title">Preface</div>
+          <div class="description" data-type="description" itemprop="description">description</div>
+          <div data-type="metadata">
+            <div data-type="document-title">Preface</div>
+          </div>
+          <figure id="someId1">
+            <figcaption>Solid <em>carbon</em> dioxide sublimes ...</figcaption>
+            <div data-type='title'>This Is A Title</div>
+            <span data-type="media" id="otherId" data-alt="This figure shows pieces of a ...">
+            </span>
+          </figure>
+          <figure id="someId2">
+          <figcaption>Solid <em>carbon</em> dioxide sublimes ...</figcaption>
+          <div data-type='title'>This Is A Title</div>
+          <span data-type="media" id="otherId" data-alt="This figure shows pieces of a ...">
+          </span>
+        </figure>
           <div data-type="abstract" id="abcde">abstract</div>
         </div>
       HTML
@@ -26,20 +53,6 @@ RSpec.describe Kitchen::Directions::BakePreface::V1 do
 
   it 'works' do
     described_class.new.bake(book: book1, title_element: 'h1')
-
-    expected = <<~HTML
-      <div class="preface" data-type="page">
-        <h1 data-type="document-title">
-          <span class="os-text" data-type="" itemprop="">Preface</span>
-        </h1>
-        <div data-type="metadata">
-          <h1 data-type="document-title">
-            <span class="os-text" data-type="" itemprop="">Preface</span>
-          </h1>
-        </div>
-      </div>
-    HTML
-
-    expect(book1.search('div.preface')).to all(match_normalized_html(expected))
+    expect(book1).to match_snapshot_auto
   end
 end

--- a/spec/recipes_spec/books/ap-physics/expected_output.xhtml
+++ b/spec/recipes_spec/books/ap-physics/expected_output.xhtml
@@ -335,13 +335,20 @@ Professor of Science Education
         <p id="auto_7dd6dad7-8641-434e-b2dc-4b729140ff5d_eip-id1167979823122"><em data-effect="italics">College Physics for AP<sup>&#xAE;</sup> Courses</em> has been written to engage students in their exploration of physics and help them relate what they learn in the classroom to their lives outside of it. Physics underlies much of what is happening today in other sciences and in technology. Thus, the book content includes interesting facts and ideas that go beyond the scope of the AP<sup>&#xAE;</sup>  course. The AP<sup>&#xAE;</sup>  Connection in each chapter directs students to the material they should focus on for the AP<sup>&#xAE;</sup>  exam, and what content&#x2014;although interesting&#x2014;is not part of the AP<sup>&#xAE;</sup>  curriculum. Physics is a beautiful and fascinating science. It is in your hands to engage and inspire your students to dive into an amazing world of physics, so they can enjoy it beyond just preparation for the AP<sup>&#xAE;</sup>  exam.</p>
         <p id="auto_7dd6dad7-8641-434e-b2dc-4b729140ff5d_eip-id1167980992946">Irina Lyublinskaya, PhD<span data-type="newline"><br /></span>Professor of Science Education</p>
       </section>
-      <figure id="auto_7dd6dad7-8641-434e-b2dc-4b729140ff5d_bigidea" data-label="">
-        <figcaption>The concept map showing major links between Big Ideas and Enduring Understandings is provided below for visual reference.
-  </figcaption>
-        <span data-type="media" id="auto_7dd6dad7-8641-434e-b2dc-4b729140ff5d_prefacemap" data-alt="conceptmap">
-          <img src="../resources/274369e885862c9e830393a3f8684cf7b55c2086" data-media-type="image/jpeg" alt="conceptmap" width="800" id="auto_7dd6dad7-8641-434e-b2dc-4b729140ff5d_1" />
-        </span>
-      </figure>
+      <div class="os-figure">
+        <figure id="auto_7dd6dad7-8641-434e-b2dc-4b729140ff5d_bigidea" data-label="">
+          <span data-type="media" id="auto_7dd6dad7-8641-434e-b2dc-4b729140ff5d_prefacemap" data-alt="conceptmap">
+            <img src="../resources/274369e885862c9e830393a3f8684cf7b55c2086" data-media-type="image/jpeg" alt="conceptmap" width="800" id="auto_7dd6dad7-8641-434e-b2dc-4b729140ff5d_1" />
+          </span>
+        </figure>
+        <div class="os-caption-container">
+          <span class="os-title-label">Figure </span>
+          <span class="os-number">1</span>
+          <span class="os-divider"> </span>
+          <span class="os-caption">The concept map showing major links between Big Ideas and Enduring Understandings is provided below for visual reference.
+  </span>
+        </div>
+      </div>
     </div>
     <div data-type="chapter">
       <div data-type="metadata" style="display: none;">

--- a/spec/snapshots/Kitchen_Directions_BakePreface_V1_works.snap
+++ b/spec/snapshots/Kitchen_Directions_BakePreface_V1_works.snap
@@ -1,0 +1,76 @@
+<html xmlns:m="http://www.w3.org/1998/Math/MathML">
+  <body>
+    <div data-type="page" class="preface">
+  <h1 data-type="document-title"><span data-type="" itemprop="" class="os-text">Preface</span>
+</h1>
+  <div data-type="metadata">
+    <h1 data-type="document-title"><span data-type="" itemprop="" class="os-text">Preface</span>
+</h1>
+  </div>
+</div>
+<div data-type="page" class="preface">
+  <h1 data-type="document-title"><span data-type="" itemprop="" class="os-text">Preface</span>
+</h1>
+  
+  <div data-type="metadata">
+    <h1 data-type="document-title"><span data-type="" itemprop="" class="os-text">Preface</span>
+</h1>
+  </div>
+  <div class="os-figure"><figure id="someId">
+    
+    
+    <span data-type="media" id="otherId" data-alt="This figure shows pieces of a ...">
+    </span>
+  </figure><div class="os-caption-container">
+  <span class="os-title-label">Figure </span>
+<span class="os-number">1</span>
+<span class="os-divider"> </span>
+<span class="os-title" data-type="title">This Is A Title</span>
+
+  <span class="os-divider"> </span>
+  <span class="os-caption">Solid <em>carbon</em> dioxide sublimes ...</span>
+</div></div>
+  
+</div>
+
+<div data-type="page" class="preface">
+  <h1 data-type="document-title"><span data-type="" itemprop="" class="os-text">Preface</span>
+</h1>
+  
+  <div data-type="metadata">
+    <h1 data-type="document-title"><span data-type="" itemprop="" class="os-text">Preface</span>
+</h1>
+  </div>
+  <div class="os-figure"><figure id="someId1">
+    
+    
+    <span data-type="media" id="otherId" data-alt="This figure shows pieces of a ...">
+    </span>
+  </figure><div class="os-caption-container">
+  <span class="os-title-label">Figure </span>
+<span class="os-number">1</span>
+<span class="os-divider"> </span>
+<span class="os-title" data-type="title">This Is A Title</span>
+
+  <span class="os-divider"> </span>
+  <span class="os-caption">Solid <em>carbon</em> dioxide sublimes ...</span>
+</div></div>
+  <div class="os-figure"><figure id="someId2">
+  
+  
+  <span data-type="media" id="otherId" data-alt="This figure shows pieces of a ...">
+  </span>
+</figure><div class="os-caption-container">
+  <span class="os-title-label">Figure </span>
+<span class="os-number">2</span>
+<span class="os-divider"> </span>
+<span class="os-title" data-type="title">This Is A Title</span>
+
+  <span class="os-divider"> </span>
+  <span class="os-caption">Solid <em>carbon</em> dioxide sublimes ...</span>
+</div></div>
+  
+</div>
+
+  </body>
+</html>


### PR DESCRIPTION
**Issue**: [5160](https://github.com/openstax/cnx-recipes/issues/5160)

**Solution**: Removed code that was baking figures in preface from each book that required it, and moved code to main "BakePreface.v1" script. This will bake figures in all books where applicable.

**For Testing**:  The following books have figures in the preface. (all other books should stay the same unless figures have been added)

1. archived_recipes>additive-manufacturing (not sure if this needs to be tested since it's archived, but adding it just in case)
2. Accounting
3. AP - Physics
4. Astronomy
5. College Success
6. Computer Science
7. Contemporary Math
8. Finance
9. Marketing
10. Nursing Internal
11. Python

