### PR TITLE
Remove unnecessary Docker Components

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,7 @@
   "workspaceFolder": "/code",
   "extensions": [
     "castwide.solargraph",
-    "rebornix.Ruby",
-    "MS-vsliveshare.vsliveshare-pack"
+    "rebornix.Ruby"
   ],
   "settings": {
     "files.trimTrailingWhitespace": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Bake `injected-exercises` in `anatomy`
+* Remove from Dockerfile `git`, `vim`, `openssh-server`, `wget`, `libicu-dev`, and `liveshare`
 
 ## [v2.0.0] - 2023-08-24
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,14 +5,9 @@ ARG EASYBAKE_VERSION=1.2.8
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    git \
-    vim \
-    openssh-server \
     build-essential \
-    wget \
     software-properties-common \
     zlib1g-dev \
-    libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install a quick colorized prompt and turn on ls coloring


### PR DESCRIPTION
[#5156](https://github.com/openstax/cnx-recipes/issues/5156)

 Remove from Dockerfile `git`, `vim`, `openssh-server`, `wget`, `libicu-dev`, and `liveshare`