### PR TITLE
fix links to chapters in References

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix links to chapter in `BakeReferences.v4`
 * Create `V4` of `BakeReferences` for `nursing-external`
 * Bake `injected-exercises` in `anatomy`
 * Remove from Dockerfile `git`, `vim`, `openssh-server`, `wget`, `libicu-dev`, and `liveshare`

--- a/lib/kitchen/directions/bake_references/v4.rb
+++ b/lib/kitchen/directions/bake_references/v4.rb
@@ -15,7 +15,7 @@ module Kitchen::Directions::BakeReferences
         chapter.append(child:
           <<~HTML
             <div class="os-chapter-area">
-              <a href="#chapTitle#{chapter.count_in(:book)}">
+              <a href="##{chapter.title.id}">
                 <h2 data-type="document-title" data-rex-keep="true">
                   <span class="os-part-text">#{I18n.t("chapter#{'.nominative' if cases}")} </span>
                   <span class="os-number">#{chapter.count_in(:book)}</span>


### PR DESCRIPTION
Changes from https://github.com/openstax/cookbook/pull/263 are causing errors when web version is creating:

![image](https://github.com/openstax/cookbook/assets/40228854/90550f54-cd1e-485a-90b9-3b5bab2b5842)
