### PR TITLE
add BakeOrderHeaders to web recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `BakeOrderHeaders` to web recipe
+
 ## [v2.8.0] - 2023-12-15
 
 * Create `WebPreBakeSetup` and `WebPostBakeRestore` directions

--- a/lib/recipes/web-generic/recipe.rb
+++ b/lib/recipes/web-generic/recipe.rb
@@ -12,7 +12,9 @@ WEB_RECIPE = Kitchen::BookRecipe.new(book_short_name: :web) do |doc, resources|
 
   # Web directions
   BakeImages.v1(book_pages: book_pages, resources: resources)
-  BakeOrderHeaders.v1(within: book_pages)
+  book_pages.each do |page_or_composite|
+    BakeOrderHeaders.v1(within: page_or_composite)
+  end
 
   # Restore
   WebPostBakeRestore.v1(book_pages: book_pages)

--- a/lib/recipes/web-generic/recipe.rb
+++ b/lib/recipes/web-generic/recipe.rb
@@ -12,6 +12,7 @@ WEB_RECIPE = Kitchen::BookRecipe.new(book_short_name: :web) do |doc, resources|
 
   # Web directions
   BakeImages.v1(book_pages: book_pages, resources: resources)
+  BakeOrderHeaders.v1(within: book_pages)
 
   # Restore
   WebPostBakeRestore.v1(book_pages: book_pages)


### PR DESCRIPTION
fixes openstax/cnx-recipes#5304

small PR with big testing scope - all web books

for QA:

- this impacts all headers in all web books
- check that the headers in a range of textbook pages (preface, intro, regular page, eoc section, answer key, etc) progress linearly from H1 (outside of `#main-content`) to H2, H3, etc (inside `#main-content`) without skipping
- styling will change a little for promoted headers
