### PR TITLE
Make Codecov working again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
       - name: Build docker image and run kitchen specs + codecov within it
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         # See https://docs.codecov.io/docs/testing-with-docker
         run: |
           ./docker/build --ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add Codecov secret value in GH settings
+
 ## [v2.20.0] - 2024-07-16
 
 * Uncommented elements needed to build `additive-manufacturing`

--- a/docker/ci_kitchen
+++ b/docker/ci_kitchen
@@ -7,8 +7,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # without it per:
 # https://github.com/codecov/codecov-ruby/blob/484767f1c3d7992a9d7fedd6dc72d35a80d04f70/lib/codecov.rb#L68-L69
 
+# CODECOV_TOKEN is added to repo settings according to:
+# https://github.com/openstax/cnx-recipes/issues/5516
+# https://docs.codecov.com/docs/adding-the-codecov-token#github-actions
+
 docker run $CI_ENV \
            -e ENABLE_CODECOV=1 -e CI=true \
+           -e CODECOV_TOKEN=${CODECOV_TOKEN} \
            -v $DIR/..:/code \
            -w /code \
            openstax/cookbook.ci:latest \


### PR DESCRIPTION
Make Codecov working again. Alina added a secret Codecov value into GH settings and docker codecov fetches that secret.

ref:
* https://github.com/openstax/cnx-recipes/issues/5516
* https://github.com/openstax/ce/issues/2214