### PR TITLE
Bake ordered lists as embedded exercise questions in `computer-science`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Fix `index` to not generate empty module
+* Add `BakeEmbeddedExerciseQuestion` for baking exercise-like things
+* Bake ordered lists as embedded exercise questions in `computer-science`
 
 ## [v2.23.0] - 2024-09-09
 

--- a/lib/kitchen/directions/bake_embedded_exercise_question.rb
+++ b/lib/kitchen/directions/bake_embedded_exercise_question.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Kitchen
+  module Directions
+    module BakeEmbeddedExerciseQuestion
+      def self.v1(question:, number:, append_to:)
+        append_to.append(child:
+          <<~HTML
+            <div data-type="exercise">
+              <div data-type="problem">
+                <span class="os-number">#{number}</span>
+                <span class="os-divider">. </span>
+                <div class="os-problem-container">#{question.cut.paste}</div>
+              </div>
+            </div>
+          HTML
+        )
+      end
+    end
+  end
+end

--- a/lib/recipes/computer-science/recipe.rb
+++ b/lib/recipes/computer-science/recipe.rb
@@ -57,6 +57,25 @@ do |doc, _resources|
       title = EocSectionTitleLinkSnippet.v1(page: section.ancestor(:page))
       section.prepend(child: title)
     end
+
+    # Convert lab numbered lists to a series of exercise questions
+    lab_item_number = 1
+    chapter.search('section.labs-assessments').each do |lab|
+      ordered_lists = lab.search('> ol')
+      next unless ordered_lists.any?
+
+      ordered_lists.each do |list|
+        list.search('> li').each do |item|
+          item.name = 'span'
+          BakeEmbeddedExerciseQuestion.v1(
+            question: item, number: lab_item_number, append_to: list
+          )
+          lab_item_number += 1
+        end
+        list.name = 'span'
+      end
+    end
+
     eoc_sections = %w[review-questions conceptual-questions practice-exercises
                       problem-set-a problem-set-b thought-provokers labs-assessments]
 

--- a/spec/kitchen_spec/directions/bake_embedded_exercise_question_spec.rb
+++ b/spec/kitchen_spec/directions/bake_embedded_exercise_question_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Kitchen::Directions::BakeEmbeddedExerciseQuestion do
+  let(:book_with_question) do
+    book_containing(html:
+      one_chapter_with_one_page_containing(
+        <<~HTML
+          <section>
+            <div>Question</div>
+          </section>
+        HTML
+      )
+    )
+  end
+
+  context 'when question and number provided' do
+    it 'bakes' do
+      section = book_with_question.search('section').first!
+      question = section.search('div').first!
+      described_class.v1(question: question, number: 1, append_to: section)
+      expect(book_with_question.pages.first).to match_snapshot_auto
+    end
+  end
+end

--- a/spec/recipes_spec/books/computer-science/expected_output.xhtml
+++ b/spec/recipes_spec/books/computer-science/expected_output.xhtml
@@ -134,6 +134,11 @@
                         <span class="os-text">Thought Provokers</span>
                       </a>
                     </li>
+                    <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-9" data-toc-type="book-content" data-toc-target-type="composite-page">
+                      <a href="#composite-page-9">
+                        <span class="os-text">Labs</span>
+                      </a>
+                    </li>
                   </ol>
                 </li>
               </ol>
@@ -147,8 +152,8 @@
             <span data-type="" itemprop="" class="os-text">Basic Functions We Expect Could Appear in Any Appendix</span>
           </a>
         </li>
-        <li class="os-toc-index" cnx-archive-shortid="" cnx-archive-uri="composite-page-9" data-toc-type="book-content" data-toc-target-type="index">
-          <a href="#composite-page-9">
+        <li class="os-toc-index" cnx-archive-shortid="" cnx-archive-uri="composite-page-10" data-toc-type="book-content" data-toc-target-type="index">
+          <a href="#composite-page-10">
             <span class="os-text">Index</span>
           </a>
         </li>
@@ -3058,6 +3063,130 @@ The amounts in raw material, work in process, and finished goods inventory maint
               </div>
             </section>
           </div>
+          <div class="os-eoc os-labs-assessments-container" data-type="composite-page" data-uuid-key=".labs-assessments" id="composite-page-9" data-book-content="true">
+            <h3 data-type="title">
+              <span class="os-text">Labs</span>
+            </h3>
+            <div data-type="metadata" style="display: none;">
+              <h1 data-type="document-title" itemprop="name">Labs</h1>
+              <span data-type="revised" data-value="2021-09-16T10:14:21.613538-05:00"></span>
+              <div class="authors">
+        By:
+<span itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author"><a href="manager" itemprop="url" data-type="cnx-id">manager</a></span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+              <div class="publishers">
+        Published By:
+            <span itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher"><a href="manager" itemprop="url" data-type="cnx-id">manager</a></span>      </div>
+              <div class="permissions">
+                <p class="copyright">
+          Copyright:
+              <span itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder"><a href="manager" itemprop="url" data-type="cnx-id">manager</a></span>        </p>
+                <p class="license">
+          Licensed:
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license" target="_blank" rel="noopener nofollow">CC BY</a>
+        </p>
+              </div>
+              <div itemprop="about" data-type="subject">Science and Technology</div>
+            </div>
+            <section data-depth="1" class="labs-assessments" id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_sect-00017">
+              <span id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_list-00004">
+                <div data-type="exercise">
+                  <div data-type="problem">
+                    <span class="os-number">1</span>
+                    <span class="os-divider">. </span>
+                    <div class="os-problem-container">
+                      <span>a</span>
+                    </div>
+                  </div>
+                </div>
+                <div data-type="exercise">
+                  <div data-type="problem">
+                    <span class="os-number">2</span>
+                    <span class="os-divider">. </span>
+                    <div class="os-problem-container">
+                      <span>b</span>
+                    </div>
+                  </div>
+                </div>
+                <div data-type="exercise">
+                  <div data-type="problem">
+                    <span class="os-number">3</span>
+                    <span class="os-divider">. </span>
+                    <div class="os-problem-container">
+                      <span>c</span>
+                    </div>
+                  </div>
+                </div>
+              </span>
+            </section>
+            <section data-depth="1" class="labs-assessments" id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_sect-u8">
+              <span id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_list-85778">
+                <div data-type="exercise">
+                  <div data-type="problem">
+                    <span class="os-number">4</span>
+                    <span class="os-divider">. </span>
+                    <div class="os-problem-container">
+                      <span>
+                        <ul>
+                          <li>d</li>
+                        </ul>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div data-type="exercise">
+                  <div data-type="problem">
+                    <span class="os-number">5</span>
+                    <span class="os-divider">. </span>
+                    <div class="os-problem-container">
+                      <span>
+                        <ol>
+                          <li>e</li>
+                        </ol>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div data-type="exercise">
+                  <div data-type="problem">
+                    <span class="os-number">6</span>
+                    <span class="os-divider">. </span>
+                    <div class="os-problem-container">
+                      <span>f</span>
+                    </div>
+                  </div>
+                </div>
+              </span>
+            </section>
+            <section data-depth="1" class="labs-assessments" id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_sect-u89">
+              <ul>
+                <li>a</li>
+                <li>b</li>
+                <li>c</li>
+              </ul>
+            </section>
+            <section data-depth="1" class="labs-assessments" id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_sect-u80">
+              <ul>
+                <li>
+                  <ul>
+                    <li>d</li>
+                  </ul>
+                </li>
+                <li>
+                  <ol>
+                    <li>e</li>
+                  </ol>
+                </li>
+                <li>f</li>
+              </ul>
+            </section>
+          </div>
         </div>
       </div>
     </div>
@@ -3330,7 +3459,7 @@ Three temperature scales are in general use:
         <p id="auto_6f2e1cb9-9e82-40a4-9b3d-6143ad421e4d_eip-774">On the Fahrenheit scale, the difference between the freezing and boiling points of water is 180 degrees. Thus, to convert Celsius degrees or Kelvins to Fahrenheit degrees, it is necessary to multiply by 180/100 = 9/5. To convert from Fahrenheit degrees to Celsius degrees or Kelvins, it is necessary to multiply by 100/180 = 5/9.</p>
       </section>
     </div>
-    <div class="os-eob os-index-container" data-type="composite-page" data-uuid-key="index" id="composite-page-9" data-book-content="true">
+    <div class="os-eob os-index-container" data-type="composite-page" data-uuid-key="index" id="composite-page-10" data-book-content="true">
       <h1 data-type="document-title">
         <span class="os-text">Index</span>
       </h1>

--- a/spec/recipes_spec/books/computer-science/input.xhtml
+++ b/spec/recipes_spec/books/computer-science/input.xhtml
@@ -1642,6 +1642,37 @@ The amounts in raw material, work in process, and finished goods inventory maint
         </div>
     </div></section>
 
+    <section data-depth="1" class="labs-assessments" id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_sect-00017"><h3 data-type="title">Assessment: Labss</h3>
+      <ol id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_list-00004">
+      <li>a</li>
+      <li>b</li>
+      <li>c</li>
+      </ol>
+      </section>
+
+    <section data-depth="1" class="labs-assessments" id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_sect-u8"><h3 data-type="title">Assessment: Labss</h3>
+      <ol id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_list-85778">
+      <li><ul><li>d</li></ul></li>
+      <li><ol><li>e</li></ol></li>
+      <li>f</li>
+      </ol>
+      </section>
+
+      <section data-depth="1" class="labs-assessments" id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_sect-u89"><h3 data-type="title">Assessment: Labss</h3>
+        <ul id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_list-00004">
+        <li>a</li>
+        <li>b</li>
+        <li>c</li>
+        </ul>
+        </section>
+
+      <section data-depth="1" class="labs-assessments" id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_sect-u80"><h3 data-type="title">Assessment: Labss</h3>
+        <ul id="auto_819baee8-f0ab-443c-9cf3-82e8247d767d_list-85778">
+        <li><ul><li>d</li></ul></li>
+        <li><ol><li>e</li></ol></li>
+        <li>f</li>
+        </ul>
+        </section>
 
 
 <div data-type="glossary" id="auto_2040a658-785c-4c4a-8e40-1404c7ab67cd_10"><h3 data-type="glossary-title">Glossary</h3>

--- a/spec/snapshots/Kitchen_Directions_BakeEmbeddedExerciseQuestion_when_question_and_number_provided_bakes.snap
+++ b/spec/snapshots/Kitchen_Directions_BakeEmbeddedExerciseQuestion_when_question_and_number_provided_bakes.snap
@@ -1,0 +1,13 @@
+<div data-type="page" id="testidOne">
+    <section>
+  
+<div data-type="exercise">
+  <div data-type="problem">
+    <span class="os-number">1</span>
+    <span class="os-divider">. </span>
+    <div class="os-problem-container"><div>Question</div></div>
+  </div>
+</div>
+</section>
+
+  </div>


### PR DESCRIPTION
<img width="874" alt="Screenshot 2024-10-17 at 3 49 19 PM" src="https://github.com/user-attachments/assets/253662bc-724e-4f42-97a9-4f48b6e59656">

Replace ordered lists with something more exercise-like in `computer-science`

These will share a style with injected exercises

This data-type might be a holdover from old injected exercise implementations (not sure).

It was already in the styles and it supported creating a distinction between injected and non-injected exercises while maintaining the same styles