### PR TITLE
Add support for unit closer pages in toc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Support `unit-closer` pages in TOC
 * Fix iframes links for Polish books
 * Create `number_parts` method in `ElementBase`
 * Create `os_number` method in `ElementBase` for creating `os-number` text

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -75,6 +75,14 @@ module Kitchen
       @is_introduction ||= has_class?('introduction')
     end
 
+    # Returns true if this page is a unit closer
+    #
+    # @return [Boolean]
+    #
+    def is_unit_closer?
+      @is_unit_closer ||= has_class?('unit-closer')
+    end
+
     # Returns  replaces generic call to page.count_in(:chapter)
     #
     # @raise [StandardError] if called on an introduction page

--- a/spec/kitchen_spec/directions/bake_toc_spec.rb
+++ b/spec/kitchen_spec/directions/bake_toc_spec.rb
@@ -121,6 +121,13 @@ RSpec.describe Kitchen::Directions::BakeToc do
               </h2>
             </div>
           </div>
+          <div data-type="page" id="p-unit-closer" class="unit-closer">
+            <h2 data-type="document-title">
+              <span class="os-number">3</span>
+              <span class="os-divider"> </span>
+              <span data-type="" itemprop="" class="os-text">Unit Closer</span>
+            </h2>
+          </div>
         </div>
         <div data-type="page" id="p8" class="appendix">
           <h1 data-type="document-title">

--- a/spec/snapshots/Kitchen_Directions_BakeToc_supports_unit_numbering.snap
+++ b/spec/snapshots/Kitchen_Directions_BakeToc_supports_unit_numbering.snap
@@ -71,6 +71,7 @@
   </ol>
 </li>
 
+    
   </ol>
 </li>
 
@@ -115,6 +116,12 @@
 </li>
 
   </ol>
+</li>
+
+    <li class="os-toc-unit-page" cnx-archive-shortid="" cnx-archive-uri="p-unit-closer" data-toc-type="book-content" data-toc-target-type="numbered-section">
+  <a href="#p-unit-closer">
+    <span class="os-number">3</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text">Unit Closer</span>
+  </a>
 </li>
 
   </ol>

--- a/spec/snapshots/Kitchen_Directions_BakeToc_works_with_unit.snap
+++ b/spec/snapshots/Kitchen_Directions_BakeToc_works_with_unit.snap
@@ -71,6 +71,7 @@
   </ol>
 </li>
 
+    
   </ol>
 </li>
 
@@ -115,6 +116,12 @@
 </li>
 
   </ol>
+</li>
+
+    <li class="os-toc-unit-page" cnx-archive-shortid="" cnx-archive-uri="p-unit-closer" data-toc-type="book-content" data-toc-target-type="numbered-section">
+  <a href="#p-unit-closer">
+    <span class="os-number">3</span><span class="os-divider"> </span><span data-type="" itemprop="" class="os-text">Unit Closer</span>
+  </a>
 </li>
 
   </ol>


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-930

The default for unit pages will remain the same: treat them as introductions

This new unit-closer class supports specifying pages that should appear at the end of the unit.



I debated on if this should be done structurally instead, like this:
```ruby
      # if this page is inside a unit that has at least one chapter and there are no chapters
      # after this page
      @is_unit_closer ||= has_ancestor?(:unit) and
        ancestor(:unit).element_children.only(ChapterElement).any? and
        ancestor(:unit)
          .element_children
          .drop_while { |el| el[:id] != self[:id] }
          .none? { |el| el[:'data-type'] == 'chapter' }
```

I decided not to do this since introductions are done with classes and it could be useful to select unit closers by a css selector. I am a little concerned that using a class could cause confusing behavior if a unit-closer is placed before the end of a unit.