### PR TITLE
Core 2510 fix abstracts super

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Do not call `BakeLearningObjectives` in `super`
+
 
 ## [v2.32.1] - 2026-04-15
 

--- a/lib/recipes/super/recipe.rb
+++ b/lib/recipes/super/recipe.rb
@@ -117,10 +117,6 @@ SUPER_RECIPE = Kitchen::BookRecipe.new(book_short_name: :super) do |doc, _resour
   BakeToc.v1(book: book)
   BakeEquations.v1(book: book, number_decorator: :parentheses)
 
-  book.chapters.each do |chapter|
-    BakeLearningObjectives.v2(chapter: chapter, skip_title_if_exists: true)
-  end
-
   BakeLinkPlaceholders.v1(book: book)
   BakeFolio.v1(book: book)
   BakeRexWrappers.v1(book: book)


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-2510

Abstracts are used for descriptions in the ancillaries service. Here in cookbook, they are expected to have list items for this version of bake learning objectives. Since we do not have learning objectives in these right now, I am just removing it. we can add it back later if needed.