### PR TITLE
Release v2.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.33.0] - 2026-08-03
+
 * Move figure captions into `figcaption` inside `figure`
 * Do not call `BakeLearningObjectives` in `super`
 * Add support for `stats-lab` to `statistics`


### PR DESCRIPTION
## Summary

Release a new minor version (v2.33.0) of the cookbook repository with the latest changes from the CHANGELOG.

## Changes Included

- Move figure captions into `figcaption` inside `figure`
- Do not call `BakeLearningObjectives` in `super`
- Add support for `stats-lab` to `statistics`
- Add support for `stats-labs` to `statistics`
- Move `excel-labs` to eoc section

## Related

- Jira ticket: https://openstax.atlassian.net/browse/CORE-2610
- Related PR in ce-styles repository (see ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)